### PR TITLE
Message bubble skeletons containment

### DIFF
--- a/src/lib/features/settings/components/settings-theme-card.svelte
+++ b/src/lib/features/settings/components/settings-theme-card.svelte
@@ -53,18 +53,18 @@
 	{@const lineW3 = compact ? 'w-6' : 'w-10'}
 	<div class={cn(conversationAreaBase, compact && 'rounded-none')}>
 		<div class="flex justify-end">
-			<div class={cn(bubbleMaxW, 'rounded-sm bg-muted/80', bubblePadding)}>
-				<div class={cn(lineH, lineW1, 'rounded-full bg-muted-foreground/30')}></div>
+			<div class={cn(bubbleMaxW, 'rounded-sm bg-muted/80 overflow-hidden min-w-0', bubblePadding)}>
+				<div class={cn(lineH, lineW1, 'max-w-full rounded-full bg-muted-foreground/30')}></div>
 			</div>
 		</div>
 		<div class="flex justify-start">
-			<div class={cn(bubbleMaxW, 'rounded-sm bg-muted/60', bubblePadding)}>
-				<div class={cn(lineH, lineW2, 'rounded-full bg-muted-foreground/25')}></div>
+			<div class={cn(bubbleMaxW, 'rounded-sm bg-muted/60 overflow-hidden min-w-0', bubblePadding)}>
+				<div class={cn(lineH, lineW2, 'max-w-full rounded-full bg-muted-foreground/25')}></div>
 			</div>
 		</div>
 		<div class="flex justify-end">
-			<div class={cn(bubbleMaxW, 'rounded-sm bg-muted/80', bubblePadding)}>
-				<div class={cn(lineH, lineW3, 'rounded-full bg-muted-foreground/30')}></div>
+			<div class={cn(bubbleMaxW, 'rounded-sm bg-muted/80 overflow-hidden min-w-0', bubblePadding)}>
+				<div class={cn(lineH, lineW3, 'max-w-full rounded-full bg-muted-foreground/30')}></div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Constrain theme preview message bubble skeletons to prevent lines from extending outside the bubbles.

---
<a href="https://cursor.com/background-agent?bcId=bc-150942f8-66c3-4426-8b58-bca12d727a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-150942f8-66c3-4426-8b58-bca12d727a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

