### PR TITLE
fix: show warning banner for images when not supported

### DIFF
--- a/src/lib/components/theme-provider/theme-provider.svelte
+++ b/src/lib/components/theme-provider/theme-provider.svelte
@@ -10,7 +10,9 @@
 	let { children, defaultFontPreset }: Props = $props();
 
 	setupThemeProvider({
-		defaultFontPreset
+		get defaultFontPreset() {
+			return defaultFontPreset;
+		}
 	});
 </script>
 

--- a/src/lib/features/chat/chat-button.svelte
+++ b/src/lib/features/chat/chat-button.svelte
@@ -95,6 +95,7 @@
 			}}
 		>
 			{#snippet child({ props: { class: _, ...props } })}
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div
 					data-active={page.url.pathname.includes(`/chat/${chat._id}`)}
 					class="group/menu-button hover:bg-sidebar-accent focus-within:bg-sidebar-accent rounded-md flex items-center gap-2 h-8.5 data-[active=true]:bg-sidebar-accent"

--- a/src/lib/features/chat/chat-view.svelte
+++ b/src/lib/features/chat/chat-view.svelte
@@ -15,6 +15,7 @@
 	import ShareButton from './chat-share-button.svelte';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import {
+		RiAlertLine as AlertIcon,
 		RiEyeLine as EyeIcon,
 		RiChatOffLine as MessageCircleOffIcon,
 		RiArrowLeftLine as ArrowLeftIcon
@@ -23,6 +24,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { BASIC_MODELS } from '$lib/ai.js';
 	import ReasoningEffortPicker from './components/reasoning-effort-picker.svelte';
+	import { supportsImages } from '$lib/features/models/openrouter';
 
 	const chatLayoutState = useChatLayout();
 	const chatViewState = useChatView();
@@ -53,6 +55,10 @@
 	);
 
 	const modelSupportsReasoning = $derived(chatLayoutState.modelSupportsReasoning(modelId.current));
+	const showImageUnsupportedBanner = $derived.by(() => {
+		const model = selectedModel;
+		return attachmentsList.current.length > 0 && model ? !supportsImages(model) : false;
+	});
 
 	const lastAssistantMessage = $derived.by(() => {
 		return chatViewState.chat?.messages.findLast((message) => message.role === 'assistant');
@@ -194,6 +200,20 @@
 									</PromptInputMobile.BannerContent>
 								</PromptInputMobile.Banner>
 							{/if}
+							<PromptInputMobile.Banner
+								dismissedByError={false}
+								dismissed={!showImageUnsupportedBanner}
+							>
+								<PromptInputMobile.BannerContent>
+									<div class="flex items-center gap-2">
+										<AlertIcon class="size-4 text-destructive shrink-0" />
+										<p class="text-sm text-destructive">
+											This model doesn't support images. Remove attachments or switch models to
+											avoid errors.
+										</p>
+									</div>
+								</PromptInputMobile.BannerContent>
+							</PromptInputMobile.Banner>
 							<PromptInputMobile.InputWrapper>
 								<PromptInputMobile.AttachmentList />
 								<PromptInputMobile.Input placeholder="Ask me anything..." />
@@ -242,6 +262,17 @@
 								</PromptInput.BannerContent>
 							</PromptInput.Banner>
 						{/if}
+						<PromptInput.Banner dismissedByError={false} dismissed={!showImageUnsupportedBanner}>
+							<PromptInput.BannerContent>
+								<div class="flex items-center gap-2">
+									<AlertIcon class="size-4 text-destructive shrink-0" />
+									<p class="text-sm text-destructive">
+										This model doesn't support images. Remove attachments or switch models to avoid
+										errors.
+									</p>
+								</div>
+							</PromptInput.BannerContent>
+						</PromptInput.Banner>
 						<PromptInput.ScrollToBottom
 							isNearBottom={autoScroll.isNearBottom}
 							scrollToBottom={autoScroll.scrollToBottom}

--- a/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/+page.svelte
+++ b/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/+page.svelte
@@ -10,6 +10,7 @@
 	import { cmdOrCtrl } from '$lib/hooks/is-mac.svelte';
 	import { FinalChat } from '$lib/components/logos';
 	import {
+		RiAlertLine as AlertIcon,
 		RiArrowRightLine as ArrowRightIcon,
 		RiChatNewLine as MessageSquarePlusIcon,
 		RiRobot2Line as RobotIcon,
@@ -23,6 +24,7 @@
 	import { BASIC_MODELS } from '$lib/ai';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import ReasoningEffortPicker from '$lib/features/chat/components/reasoning-effort-picker.svelte';
+	import { supportsImages } from '$lib/features/models/openrouter';
 
 	let { data } = $props();
 
@@ -69,6 +71,13 @@
 	);
 
 	const modelSupportsReasoning = $derived(chatLayoutState.modelSupportsReasoning(modelId.current));
+	const selectedModel = $derived(
+		chatLayoutState.models.find((model) => model.id === modelId.current)
+	);
+	const showImageUnsupportedBanner = $derived.by(() => {
+		const model = selectedModel;
+		return attachmentsList.current.length > 0 && model ? !supportsImages(model) : false;
+	});
 </script>
 
 <div class="w-full h-full flex flex-col px-4 md:items-center md:justify-center md:gap-12">
@@ -156,6 +165,17 @@
 						</PromptInputMobile.BannerContent>
 					</PromptInputMobile.Banner>
 				{/if}
+				<PromptInputMobile.Banner dismissedByError={false} dismissed={!showImageUnsupportedBanner}>
+					<PromptInputMobile.BannerContent>
+						<div class="flex items-center gap-2">
+							<AlertIcon class="size-4 text-destructive shrink-0" />
+							<p class="text-sm text-destructive">
+								This model doesn't support images. Remove attachments or switch models to avoid
+								errors.
+							</p>
+						</div>
+					</PromptInputMobile.BannerContent>
+				</PromptInputMobile.Banner>
 				<PromptInputMobile.InputWrapper>
 					<PromptInputMobile.AttachmentList />
 					<PromptInputMobile.Input placeholder="Ask me anything..." />
@@ -202,6 +222,17 @@
 					</PromptInput.BannerContent>
 				</PromptInput.Banner>
 			{/if}
+			<PromptInput.Banner dismissedByError={false} dismissed={!showImageUnsupportedBanner}>
+				<PromptInput.BannerContent>
+					<div class="flex items-center gap-2">
+						<AlertIcon class="size-4 text-destructive shrink-0" />
+						<p class="text-sm text-destructive">
+							This model doesn't support images. Remove attachments or switch models to avoid
+							errors.
+						</p>
+					</div>
+				</PromptInput.BannerContent>
+			</PromptInput.Banner>
 			<PromptInput.Content>
 				<PromptInput.AttachmentList />
 				<PromptInput.Textarea placeholder="Ask me anything..." />

--- a/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/[chatId]/og.png/og-image.svelte
+++ b/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/[chatId]/og.png/og-image.svelte
@@ -29,16 +29,16 @@
 		return removeMarkdown(text);
 	};
 
-	const userText = getUserMessageText(userMessage);
-	const assistantText = getAssistantMessageText(assistantMessage);
+	const userText = $derived(getUserMessageText(userMessage));
+	const assistantText = $derived(getAssistantMessageText(assistantMessage));
 
 	const truncateText = (text: string, maxLength: number): string => {
 		if (text.length <= maxLength) return text;
 		return text.slice(0, maxLength - 3) + '...';
 	};
 
-	const displayUserText = truncateText(userText, 200);
-	const displayAssistantText = truncateText(assistantText, 400);
+	const displayUserText = $derived(truncateText(userText, 200));
+	const displayAssistantText = $derived(truncateText(assistantText, 400));
 </script>
 
 <div


### PR DESCRIPTION
Fixes #40 

Now when users upload attachments and the selected model doesn't support it they will see a warning banner

<img width="856" height="405" alt="CleanShot 2026-02-02 at 10 14 22" src="https://github.com/user-attachments/assets/51db3307-715b-4be6-a397-53debd8df536" />
