### PR TITLE
feat: Repack streams before storing them

### DIFF
--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -21,7 +21,11 @@ import {
 } from './chats.utils';
 import { TITLE_GENERATION_MODEL } from '../ai.js';
 import { fetchLinkContentTool } from './ai.utils.js';
-import { createChunkAppender, partsToModelMessage } from '../utils/stream-transport-protocol';
+import {
+	createChunkAppender,
+	partsToModelMessage,
+	repackStream
+} from '../utils/stream-transport-protocol';
 import { persistentTextStreaming } from './persistent-text-streaming.utils';
 import { r2 } from './r2';
 import { createKey } from './chatAttachments.utils';
@@ -465,9 +469,11 @@ ${systemPrompt}
 					await Promise.all(uploadPromises);
 				}
 
+				const repackedContent = repackStream(content).expect('Failed to repack stream');
+
 				await ctx.runMutation(internal.messages.updateMessageContent, {
 					messageId: last.assistantMessage._id,
-					content,
+					content: repackedContent,
 					meta: {
 						generationId: openRouterGenId,
 						tokenUsage: usage.totalTokens,

--- a/src/lib/convex/migrations.ts
+++ b/src/lib/convex/migrations.ts
@@ -1,6 +1,7 @@
 import { Migrations } from '@convex-dev/migrations';
 import { components, internal } from './_generated/api';
 import type { DataModel } from './_generated/dataModel';
+import { repackStream } from '../utils/stream-transport-protocol';
 
 export const migrations = new Migrations<DataModel>(components.migrations);
 
@@ -18,4 +19,25 @@ export const assistantMessagesAddUserId = migrations.define({
 	}
 });
 
-export const runAll = migrations.runner([internal.migrations.assistantMessagesAddUserId]);
+export const repackStreams = migrations.define({
+	table: 'messages',
+	migrateOne: async (ctx, message) => {
+		// Only process assistant messages with content
+		if (message.role !== 'assistant' || !message.content) return;
+
+		const result = repackStream(message.content);
+		if (result.isErr()) {
+			console.error(`Failed to repack stream for message ${message._id}:`, result.error);
+			return;
+		}
+
+		await ctx.db.patch(message._id, {
+			content: result.value
+		});
+	}
+});
+
+export const runAll = migrations.runner([
+	internal.migrations.assistantMessagesAddUserId,
+	internal.migrations.repackStreams
+]);

--- a/src/lib/utils/stream-transport-protocol/index.ts
+++ b/src/lib/utils/stream-transport-protocol/index.ts
@@ -1,10 +1,14 @@
-import { err, type Result } from 'nevereverthrow';
+import { err, ok, type Result } from 'nevereverthrow';
 import { DeserializeStreamError, type StreamResult } from './types';
 import { deserializeStream as deserializeStreamV1 } from './v1';
-import { deserializeStream as deserializeStreamV2, createChunkAppender } from './v2';
+import {
+	deserializeStream as deserializeStreamV2,
+	createChunkAppender,
+	serializeParts
+} from './v2';
 import type { ModelMessage, ReasoningOutput, TextPart } from 'ai';
 
-export { createChunkAppender, type StreamResult };
+export { createChunkAppender, type StreamResult, serializeParts };
 
 export function deserializeStream({
 	text,
@@ -115,4 +119,14 @@ export function partsToModelMessage(parts: StreamResult): ModelMessage[] {
 	JSON.stringify(messages, null, 2);
 
 	return messages;
+}
+
+export function repackStream(context: string): Result<string, DeserializeStreamError> {
+	const partsResult = deserializeStream({ text: context });
+	if (partsResult.isErr()) {
+		return err(partsResult.error);
+	}
+
+	const parts = partsResult.value.stack;
+	return ok(serializeParts(parts));
 }


### PR DESCRIPTION
Previously we just stored the stream how it came in so:
```
rd5: hello rd7:  world
```

But we can improve the parsing performance and full text search by simply optimizing this before it's stored to the database. (It will also save us some storage)

So the stream will be collapsed into:

```
rd: 12 hello world
```