### PR TITLE
feat(chat): PDF and multi-format attachments (AI SDK FilePart)

### DIFF
--- a/src/lib/components/ui/file-drop-zone/file-drop-zone.svelte.ts
+++ b/src/lib/components/ui/file-drop-zone/file-drop-zone.svelte.ts
@@ -73,8 +73,8 @@ class FileDropZoneState {
 		const fileName = file.name.toLowerCase();
 
 		const isAcceptable = acceptedTypes.some((pattern) => {
-			// check extension like .mp4
-			if (fileType.startsWith('.')) {
+			// Accept attribute entries like `.pdf` when MIME is missing or wrong
+			if (pattern.startsWith('.')) {
 				return fileName.endsWith(pattern);
 			}
 

--- a/src/lib/convex/chatAttachments.ts
+++ b/src/lib/convex/chatAttachments.ts
@@ -92,7 +92,8 @@ export const create = internalMutation({
 		messageId: v.id('messages'),
 		key: v.string(),
 		userId: v.string(),
-		mediaType: v.string()
+		mediaType: v.string(),
+		fileName: v.optional(v.string())
 	},
 	handler: async (ctx, args) => {
 		await ctx.db.insert('chatAttachments', {
@@ -100,7 +101,8 @@ export const create = internalMutation({
 			messageId: args.messageId,
 			key: args.key,
 			userId: args.userId,
-			mediaType: args.mediaType
+			mediaType: args.mediaType,
+			...(args.fileName !== undefined ? { fileName: args.fileName } : {})
 		});
 	}
 });

--- a/src/lib/convex/chats.ts
+++ b/src/lib/convex/chats.ts
@@ -436,7 +436,8 @@ export const branchFromMessage = mutation({
 							chatId: newChatId,
 							userId: user.subject,
 							key: a.key,
-							mediaType: a.mediaType
+							mediaType: a.mediaType,
+							...(a.fileName !== undefined ? { fileName: a.fileName } : {})
 						})
 					)
 				);

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -11,6 +11,8 @@ import {
 	ToolLoopAgent,
 	type StreamTextResult,
 	type ModelMessage,
+	type ImagePart,
+	type FilePart,
 	streamText,
 	smoothStream
 } from 'ai';
@@ -320,7 +322,7 @@ export const streamMessage = httpAction(async (ctx, request) => {
 												...message.attachments.map((attachment) => ({
 													type: 'file' as const,
 													data: attachment.url,
-													mediaType: 'image'
+													mediaType: attachment.mediaType
 												}))
 											]
 										}
@@ -329,13 +331,16 @@ export const streamMessage = httpAction(async (ctx, request) => {
 						];
 					}
 
-					const imageParts = message.attachments?.map(
-						(attachment) =>
-							({
-								type: 'image',
-								image: attachment.url
-							}) as const
-					);
+					const attachmentParts: (ImagePart | FilePart)[] =
+						message.attachments?.map((attachment) =>
+							attachment.mediaType.startsWith('image/')
+								? ({ type: 'image', image: attachment.url } satisfies ImagePart)
+								: ({
+										type: 'file',
+										data: attachment.url,
+										mediaType: attachment.mediaType
+									} satisfies FilePart)
+						) ?? [];
 
 					return {
 						role: message.role,
@@ -344,9 +349,9 @@ export const streamMessage = httpAction(async (ctx, request) => {
 								type: 'text',
 								text: message.content ?? ''
 							},
-							...(imageParts ?? [])
+							...attachmentParts
 						]
-					};
+					} satisfies ModelMessage;
 				});
 
 				if (systemPrompt) {

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -46,7 +46,8 @@ export const Prompt = v.object({
 			v.object({
 				url: v.string(),
 				key: v.string(),
-				mediaType: v.string()
+				mediaType: v.string(),
+				fileName: v.optional(v.string())
 			})
 		)
 	),
@@ -163,7 +164,8 @@ export const create = mutation({
 						messageId: userMessageId,
 						key: attachment.key,
 						userId: user.subject,
-						mediaType: attachment.mediaType
+						mediaType: attachment.mediaType,
+						fileName: attachment.fileName
 					});
 				})
 			);

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -107,7 +107,8 @@ export default defineSchema({
 		chatId: v.id('chats'),
 		messageId: v.id('messages'),
 		key: v.string(),
-		mediaType: v.string()
+		mediaType: v.string(),
+		fileName: v.optional(v.string())
 	})
 		.index('by_chat', ['chatId'])
 		.index('by_message', ['messageId'])

--- a/src/lib/features/chat/attachment-download.svelte
+++ b/src/lib/features/chat/attachment-download.svelte
@@ -2,7 +2,7 @@
 	import { Button, type ButtonVariant, type ButtonSize } from '$lib/components/ui/button';
 	import { AccessTokenCtx } from '$lib/context.svelte';
 	import { env } from '$lib/env.client';
-	import { getImageFileExtension } from '$lib/utils/media-types';
+	import { getAttachmentFileExtension } from '$lib/utils/media-types';
 	import { RiDownload2Line as DownloadIcon } from 'remixicon-svelte';
 
 	let {
@@ -22,7 +22,7 @@
 	const accessToken = AccessTokenCtx.get();
 
 	const resolvedFilename = $derived(
-		filename ?? `attachment${getImageFileExtension(mediaType) ?? '.file'}`
+		filename ?? `attachment${getAttachmentFileExtension(mediaType) ?? '.file'}`
 	);
 
 	async function handleDownload() {

--- a/src/lib/features/chat/chat-attachment-display.svelte
+++ b/src/lib/features/chat/chat-attachment-display.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import type { Doc } from '$lib/convex/_generated/dataModel';
+	import { cn } from '$lib/utils';
+	import {
+		attachmentTypeLabel,
+		isImageAttachmentMediaType
+	} from '$lib/utils/chat-attachment-types';
+	import { getAttachmentFileExtension } from '$lib/utils/media-types';
+	import { RiEyeLine as EyeIcon, RiFileLine as FileIcon } from 'remixicon-svelte';
+	import { tv } from 'tailwind-variants';
+	import AttachmentDownload from './attachment-download.svelte';
+
+	const variants = tv({
+		base: 'rounded-md overflow-hidden max-w-sm relative border border-border group/attachment',
+		variants: {
+			size: {
+				sm: 'max-w-2xs',
+				lg: 'max-w-sm'
+			}
+		}
+	});
+
+	type Props = {
+		attachment: Doc<'chatAttachments'> & { url: string };
+		size: 'sm' | 'lg';
+		className?: string;
+	};
+
+	let { attachment, size = 'sm', className }: Props = $props();
+
+	const isImage = $derived(isImageAttachmentMediaType(attachment.mediaType));
+	const downloadName = $derived(
+		`attachment${getAttachmentFileExtension(attachment.mediaType) ?? '.file'}`
+	);
+</script>
+
+<div class={cn(variants({ size }), className)}>
+	<div
+		class="absolute right-2 top-2 md:opacity-0 group-hover/attachment:opacity-100 transition-opacity duration-200"
+	>
+		<AttachmentDownload
+			attachmentKey={attachment.key}
+			mediaType={attachment.mediaType}
+			filename={downloadName}
+			size="icon"
+			variant="outline"
+		/>
+	</div>
+	<div
+		class="absolute left-2 top-2 md:opacity-0 group-hover/attachment:opacity-100 transition-opacity duration-200"
+	>
+		<Button
+			href={attachment.url}
+			size="icon"
+			variant="outline"
+			class="cursor-pointer"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<EyeIcon class="size-4" />
+		</Button>
+	</div>
+	{#if isImage}
+		<!-- svelte-ignore a11y_missing_attribute -->
+		<img src={attachment.url} class="object-cover" alt="" data-key={attachment.key} />
+	{:else}
+		<div
+			class="bg-muted text-muted-foreground flex aspect-square max-h-48 flex-col items-center justify-center gap-1 p-3 text-center text-xs"
+			data-key={attachment.key}
+		>
+			<FileIcon class="size-8 shrink-0 opacity-80" />
+			<span class="font-medium leading-tight">{attachmentTypeLabel(attachment.mediaType)}</span>
+		</div>
+	{/if}
+</div>

--- a/src/lib/features/chat/chat-attachment-display.svelte
+++ b/src/lib/features/chat/chat-attachment-display.svelte
@@ -1,22 +1,16 @@
 <script lang="ts">
-	import { Button } from '$lib/components/ui/button';
 	import type { Doc } from '$lib/convex/_generated/dataModel';
 	import { cn } from '$lib/utils';
-	import {
-		attachmentTypeLabel,
-		isImageAttachmentMediaType
-	} from '$lib/utils/chat-attachment-types';
-	import { getAttachmentFileExtension } from '$lib/utils/media-types';
-	import { RiEyeLine as EyeIcon, RiFileLine as FileIcon } from 'remixicon-svelte';
+	import { fallbackAttachmentDisplayName, isImageAttachmentMediaType } from '$lib/utils/chat-attachment-types';
 	import { tv } from 'tailwind-variants';
-	import AttachmentDownload from './attachment-download.svelte';
+	import ChatNonImageAttachmentRow from './chat-non-image-attachment-row.svelte';
 
 	const variants = tv({
-		base: 'rounded-md overflow-hidden max-w-sm relative border border-border group/attachment',
+		base: 'rounded-xl overflow-hidden max-w-md w-full relative',
 		variants: {
 			size: {
-				sm: 'max-w-2xs',
-				lg: 'max-w-sm'
+				sm: 'max-w-sm',
+				lg: 'max-w-md'
 			}
 		}
 	});
@@ -30,47 +24,31 @@
 	let { attachment, size = 'sm', className }: Props = $props();
 
 	const isImage = $derived(isImageAttachmentMediaType(attachment.mediaType));
-	const downloadName = $derived(
-		`attachment${getAttachmentFileExtension(attachment.mediaType) ?? '.file'}`
+	const displayFileName = $derived(
+		attachment.fileName ?? fallbackAttachmentDisplayName(attachment.mediaType)
 	);
 </script>
 
-<div class={cn(variants({ size }), className)}>
-	<div
-		class="absolute right-2 top-2 md:opacity-0 group-hover/attachment:opacity-100 transition-opacity duration-200"
-	>
-		<AttachmentDownload
-			attachmentKey={attachment.key}
-			mediaType={attachment.mediaType}
-			filename={downloadName}
-			size="icon"
-			variant="outline"
-		/>
-	</div>
-	<div
-		class="absolute left-2 top-2 md:opacity-0 group-hover/attachment:opacity-100 transition-opacity duration-200"
-	>
-		<Button
-			href={attachment.url}
-			size="icon"
-			variant="outline"
-			class="cursor-pointer"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			<EyeIcon class="size-4" />
-		</Button>
-	</div>
+<a
+	href={attachment.url}
+	target="_blank"
+	rel="noopener noreferrer"
+	class={cn(
+		variants({ size }),
+		className,
+		isImage && 'border border-border bg-card',
+		'block cursor-pointer rounded-xl outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+	)}
+	aria-label="Open attachment"
+>
 	{#if isImage}
 		<!-- svelte-ignore a11y_missing_attribute -->
 		<img src={attachment.url} class="object-cover" alt="" data-key={attachment.key} />
 	{:else}
-		<div
-			class="bg-muted text-muted-foreground flex aspect-square max-h-48 flex-col items-center justify-center gap-1 p-3 text-center text-xs"
-			data-key={attachment.key}
-		>
-			<FileIcon class="size-8 shrink-0 opacity-80" />
-			<span class="font-medium leading-tight">{attachmentTypeLabel(attachment.mediaType)}</span>
-		</div>
+		<ChatNonImageAttachmentRow
+			fileName={displayFileName}
+			mediaType={attachment.mediaType}
+			class="shadow-none"
+		/>
 	{/if}
-</div>
+</a>

--- a/src/lib/features/chat/chat-attachment-display.svelte
+++ b/src/lib/features/chat/chat-attachment-display.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import type { Doc } from '$lib/convex/_generated/dataModel';
 	import { cn } from '$lib/utils';
-	import { fallbackAttachmentDisplayName, isImageAttachmentMediaType } from '$lib/utils/chat-attachment-types';
+	import {
+		fallbackAttachmentDisplayName,
+		isImageAttachmentMediaType
+	} from '$lib/utils/chat-attachment-types';
 	import { tv } from 'tailwind-variants';
 	import ChatNonImageAttachmentRow from './chat-non-image-attachment-row.svelte';
 

--- a/src/lib/features/chat/chat-attachment-uploader.svelte.ts
+++ b/src/lib/features/chat/chat-attachment-uploader.svelte.ts
@@ -23,7 +23,8 @@ export class ChatAttachmentUploader {
 	async upload(file: File): Promise<{ url: string; key: string; mediaType: string }> {
 		const key = await this.uploadFile(file);
 		const url = await this.client.query(api.chatAttachments.getFileUrl, { key });
-		const mediaType = file.type || guessMediaTypeFromFileName(file.name) || 'application/octet-stream';
+		const mediaType =
+			file.type || guessMediaTypeFromFileName(file.name) || 'application/octet-stream';
 		return { url, key, mediaType };
 	}
 

--- a/src/lib/features/chat/chat-attachment-uploader.svelte.ts
+++ b/src/lib/features/chat/chat-attachment-uploader.svelte.ts
@@ -2,6 +2,7 @@ import { api } from '$lib/convex/_generated/api';
 import { useUploadFile } from '@convex-dev/r2/svelte';
 import { useConvexClient } from 'convex-svelte';
 import type { ConvexClient } from 'convex/browser';
+import { guessMediaTypeFromFileName } from '$lib/utils/chat-attachment-types';
 
 export class ChatAttachmentUploader {
 	private uploadFile: ReturnType<typeof useUploadFile>;
@@ -22,7 +23,8 @@ export class ChatAttachmentUploader {
 	async upload(file: File): Promise<{ url: string; key: string; mediaType: string }> {
 		const key = await this.uploadFile(file);
 		const url = await this.client.query(api.chatAttachments.getFileUrl, { key });
-		return { url, key, mediaType: file.type };
+		const mediaType = file.type || guessMediaTypeFromFileName(file.name) || 'application/octet-stream';
+		return { url, key, mediaType };
 	}
 
 	async uploadMany(files: File[]) {

--- a/src/lib/features/chat/chat-image-attachment.svelte
+++ b/src/lib/features/chat/chat-image-attachment.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
-	import { Button } from '$lib/components/ui/button';
 	import type { Doc } from '$lib/convex/_generated/dataModel';
 	import { cn } from '$lib/utils';
-	import { RiEyeLine as EyeIcon } from 'remixicon-svelte';
 	import { tv } from 'tailwind-variants';
-	import AttachmentDownload from './attachment-download.svelte';
 
 	const imageAttachmentVariants = tv({
-		base: 'rounded-md overflow-hidden max-w-sm relative border border-border group/image',
+		base: 'rounded-md overflow-hidden max-w-sm relative border border-border',
 		variants: {
 			size: {
 				sm: 'max-w-2xs',
@@ -25,32 +22,17 @@
 	let { attachment, size = 'sm', className }: Props = $props();
 </script>
 
-<div class={cn(imageAttachmentVariants({ size }), className)}>
-	<div
-		class="absolute right-2 top-2 md:opacity-0 group-hover/image:opacity-100 transition-opacity duration-200"
-	>
-		<AttachmentDownload
-			attachmentKey={attachment.key}
-			mediaType={attachment.mediaType ?? 'image/png'}
-			filename="generated-image"
-			size="icon"
-			variant="outline"
-		/>
-	</div>
-	<div
-		class="absolute left-2 top-2 md:opacity-0 group-hover/image:opacity-100 transition-opacity duration-200"
-	>
-		<Button
-			href={attachment.url}
-			size="icon"
-			variant="outline"
-			class="cursor-pointer"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			<EyeIcon class="size-4" />
-		</Button>
-	</div>
+<a
+	href={attachment.url}
+	target="_blank"
+	rel="noopener noreferrer"
+	class={cn(
+		imageAttachmentVariants({ size }),
+		className,
+		'block cursor-pointer outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+	)}
+	aria-label="Open image attachment"
+>
 	<!-- svelte-ignore a11y_missing_attribute -->
-	<img src={attachment.url} class="object-cover" data-key={attachment.key} />
-</div>
+	<img src={attachment.url} class="object-cover" alt="" data-key={attachment.key} />
+</a>

--- a/src/lib/features/chat/chat-message.svelte
+++ b/src/lib/features/chat/chat-message.svelte
@@ -11,7 +11,7 @@
 	import ChatBranchButton from './chat-branch-button.svelte';
 	import type { Id } from '$lib/convex/_generated/dataModel.js';
 	import { useMedia } from '$lib/hooks/use-media.svelte';
-	import ChatImageAttachment from './chat-image-attachment.svelte';
+	import ChatAttachmentDisplay from './chat-attachment-display.svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 
 	const chatMessageVariants = tv({
@@ -75,7 +75,7 @@
 		{#if message.attachments}
 			<div class="w-full justify-end flex items-center gap-2">
 				{#each message.attachments as attachment (attachment.key)}
-					<ChatImageAttachment {attachment} size="sm" />
+					<ChatAttachmentDisplay {attachment} size="sm" />
 				{/each}
 			</div>
 		{/if}

--- a/src/lib/features/chat/chat-non-image-attachment-row.svelte
+++ b/src/lib/features/chat/chat-non-image-attachment-row.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { attachmentTypeLabel } from '$lib/utils/chat-attachment-types';
+	import { RiFileLine as FileIcon } from 'remixicon-svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		fileName,
+		mediaType,
+		compact = false,
+		class: className,
+		...rest
+	}: HTMLAttributes<HTMLDivElement> & {
+		fileName: string;
+		mediaType: string;
+		compact?: boolean;
+	} = $props();
+
+	const typeLabel = $derived(attachmentTypeLabel(mediaType));
+</script>
+
+<div
+	class={cn(
+		'text-foreground flex w-full min-w-0 items-center rounded-xl border border-border bg-card shadow-sm',
+		compact ? 'gap-2 px-2.5 py-1.5' : 'gap-3 px-3 py-2.5',
+		className
+	)}
+	{...rest}
+>
+	<div
+		class={cn(
+			'bg-muted text-foreground flex shrink-0 items-center justify-center rounded-lg border border-border/80',
+			compact ? 'size-8' : 'size-10'
+		)}
+	>
+		<FileIcon class={compact ? 'size-4' : 'size-5'} />
+	</div>
+	<div class="min-w-0 flex-1 text-left">
+		<p class={cn('truncate font-semibold leading-tight', compact ? 'text-xs' : 'text-sm')}>
+			{fileName}
+		</p>
+		<p class="text-muted-foreground text-xs leading-tight">{typeLabel}</p>
+	</div>
+</div>

--- a/src/lib/features/chat/chat-view.svelte
+++ b/src/lib/features/chat/chat-view.svelte
@@ -43,10 +43,9 @@
 
 	const chatAttachmentUploader = new ChatAttachmentUploader();
 
-	const attachmentsList = new PersistedState<{ url: string; key: string; mediaType: string }[]>(
-		'chat-attachments',
-		[]
-	);
+	const attachmentsList = new PersistedState<
+		{ url: string; key: string; mediaType: string; fileName?: string }[]
+	>('chat-attachments', []);
 
 	const sidebar = Sidebar.useSidebar();
 

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-add-attachment.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-add-attachment.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import * as FileDropZone from '$lib/components/ui/file-drop-zone';
 	import { usePromptInputAttachmentButton } from '../prompt-input/prompt-input.svelte.js';
-	import { RiImageAddLine as ImagePlusIcon } from 'remixicon-svelte';
+	import { RiAttachment2 as AttachmentIcon } from 'remixicon-svelte';
 	import PromptInputPlusItem from './prompt-input-plus-item.svelte';
 
 	usePromptInputAttachmentButton();
 </script>
 
-<FileDropZone.Trigger>
+<FileDropZone.Trigger aria-label="Attach images, PDFs, or text files">
 	<PromptInputPlusItem>
-		<ImagePlusIcon class="size-4" />
-		Add Image
+		<AttachmentIcon class="size-4" />
+		Attach file
 	</PromptInputPlusItem>
 </FileDropZone.Trigger>

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-attachment-list.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-attachment-list.svelte
@@ -5,11 +5,11 @@
 	import { RiCloseLine as XIcon } from 'remixicon-svelte';
 	import { animated } from 'animated-svelte';
 	import {
-		attachmentTypeLabel,
+		fallbackAttachmentDisplayName,
 		guessMediaTypeFromFileName,
 		isImageAttachmentMediaType
 	} from '$lib/utils/chat-attachment-types';
-	import { RiFileLine as FileIcon } from 'remixicon-svelte';
+	import ChatNonImageAttachmentRow from '$lib/features/chat/chat-non-image-attachment-row.svelte';
 
 	let { class: className, ...rest }: HTMLAttributes<HTMLDivElement> = $props();
 
@@ -32,32 +32,47 @@
 
 <div
 	class={cn(
-		'flex items-center w-full gap-2 h-0 transition-all bg-accent/50 px-3 border-transparent',
-		'data-[has-attachments=true]:py-2 data-[has-attachments=true]:h-18 data-[has-attachments=true]:border-b data-[has-attachments=true]:border-border',
+		'flex w-full flex-wrap items-center gap-2 min-h-0 transition-all bg-accent/50 px-3 border-transparent',
+		'data-[has-attachments=true]:py-2 data-[has-attachments=true]:min-h-[4.75rem] data-[has-attachments=true]:border-b data-[has-attachments=true]:border-border',
 		className
 	)}
 	data-has-attachments={hasAttachments}
 	{...rest}
 >
-	{#each uploadedAttachments as { url, key, mediaType } (key)}
-		<div class="size-12 rounded-sm border relative overflow-hidden" data-state="uploaded">
+	{#each uploadedAttachments as { url, key, mediaType, fileName } (key)}
+		<div
+			class={cn(
+				'relative shrink-0',
+				isImageAttachmentMediaType(mediaType) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+			)}
+			data-state="uploaded"
+		>
 			<button
 				type="button"
-				class="absolute cursor-pointer bg-background flex items-center justify-center -top-1.5 -right-1.5 rounded-full border border-border size-5 z-10"
+				class="absolute z-20 flex size-5 cursor-pointer items-center justify-center rounded-full border border-border bg-background -top-1.5 -right-1.5"
 				onclick={() => attachmentListState.rootState.deleteAttachment(key)}
 			>
 				<XIcon class="size-3.5" />
 			</button>
-			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+			<a
+				href={url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class={cn(
+					isImageAttachmentMediaType(mediaType)
+						? 'flex size-12 overflow-hidden rounded-md border border-border'
+						: 'block w-full overflow-hidden rounded-xl border border-border'
+				)}
+			>
 				{#if isImageAttachmentMediaType(mediaType)}
-					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+					<img src={url} alt="" class="size-full object-cover" />
 				{:else}
-					<div
-						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
-					>
-						<FileIcon class="size-4 shrink-0 opacity-80" />
-						<span class="line-clamp-2">{attachmentTypeLabel(mediaType)}</span>
-					</div>
+					<ChatNonImageAttachmentRow
+						compact
+						fileName={fileName ?? fallbackAttachmentDisplayName(mediaType)}
+						{mediaType}
+						class="border-0 bg-background/80 shadow-none"
+					/>
 				{/if}
 			</a>
 		</div>
@@ -66,22 +81,34 @@
 		{@const url = URL.createObjectURL(file)}
 		{@const effectiveMime = file.type || guessMediaTypeFromFileName(file.name) || ''}
 		<animated.div
-			class="size-12 rounded-sm border relative animate-pulse overflow-hidden"
+			class={cn(
+				'relative shrink-0 animate-pulse',
+				isImageAttachmentMediaType(effectiveMime) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+			)}
 			initial={{ scale: 0.75, opacity: 0, y: 10 }}
 			animate={{ scale: 1, opacity: 1, y: 0 }}
 			transition={{ duration: 0.15, delay: 0, timingFunction: 'ease-out' }}
 			data-state="uploading"
 		>
-			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+			<a
+				href={url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class={cn(
+					isImageAttachmentMediaType(effectiveMime)
+						? 'flex size-12 overflow-hidden rounded-md border border-border'
+						: 'block w-full overflow-hidden rounded-xl border border-border'
+				)}
+			>
 				{#if isImageAttachmentMediaType(effectiveMime)}
-					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+					<img src={url} alt="" class="size-full object-cover" />
 				{:else}
-					<div
-						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
-					>
-						<FileIcon class="size-4 shrink-0 opacity-80" />
-						<span class="line-clamp-2">{attachmentTypeLabel(effectiveMime || 'File')}</span>
-					</div>
+					<ChatNonImageAttachmentRow
+						compact
+						fileName={file.name}
+						mediaType={effectiveMime || 'application/octet-stream'}
+						class="border-0 bg-background/80 shadow-none"
+					/>
 				{/if}
 			</a>
 		</animated.div>

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-attachment-list.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-attachment-list.svelte
@@ -4,6 +4,12 @@
 	import { usePromptInputAttachmentList } from '../prompt-input/prompt-input.svelte.js';
 	import { RiCloseLine as XIcon } from 'remixicon-svelte';
 	import { animated } from 'animated-svelte';
+	import {
+		attachmentTypeLabel,
+		guessMediaTypeFromFileName,
+		isImageAttachmentMediaType
+	} from '$lib/utils/chat-attachment-types';
+	import { RiFileLine as FileIcon } from 'remixicon-svelte';
 
 	let { class: className, ...rest }: HTMLAttributes<HTMLDivElement> = $props();
 
@@ -33,31 +39,50 @@
 	data-has-attachments={hasAttachments}
 	{...rest}
 >
-	{#each uploadedAttachments as { url, key } (key)}
-		<div class="size-12 rounded-sm border relative" data-state="uploaded">
+	{#each uploadedAttachments as { url, key, mediaType } (key)}
+		<div class="size-12 rounded-sm border relative overflow-hidden" data-state="uploaded">
 			<button
 				type="button"
-				class="absolute cursor-pointer bg-background flex items-center justify-center -top-1.5 -right-1.5 rounded-full border border-border size-5"
+				class="absolute cursor-pointer bg-background flex items-center justify-center -top-1.5 -right-1.5 rounded-full border border-border size-5 z-10"
 				onclick={() => attachmentListState.rootState.deleteAttachment(key)}
 			>
 				<XIcon class="size-3.5" />
 			</button>
-			<a href={url} target="_blank" rel="noopener noreferrer">
-				<img src={url} alt="Attachment" class="size-full object-cover rounded-sm" />
+			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+				{#if isImageAttachmentMediaType(mediaType)}
+					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+				{:else}
+					<div
+						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
+					>
+						<FileIcon class="size-4 shrink-0 opacity-80" />
+						<span class="line-clamp-2">{attachmentTypeLabel(mediaType)}</span>
+					</div>
+				{/if}
 			</a>
 		</div>
 	{/each}
 	{#each attachmentListState.rootState.uploadingAttachments as [name, file] (name)}
 		{@const url = URL.createObjectURL(file)}
+		{@const effectiveMime = file.type || guessMediaTypeFromFileName(file.name) || ''}
 		<animated.div
-			class="size-12 rounded-sm border relative animate-pulse"
+			class="size-12 rounded-sm border relative animate-pulse overflow-hidden"
 			initial={{ scale: 0.75, opacity: 0, y: 10 }}
 			animate={{ scale: 1, opacity: 1, y: 0 }}
 			transition={{ duration: 0.15, delay: 0, timingFunction: 'ease-out' }}
 			data-state="uploading"
 		>
-			<a href={url} target="_blank" rel="noopener noreferrer">
-				<img src={url} alt="Attachment" class="size-full object-cover rounded-sm" />
+			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+				{#if isImageAttachmentMediaType(effectiveMime)}
+					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+				{:else}
+					<div
+						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
+					>
+						<FileIcon class="size-4 shrink-0 opacity-80" />
+						<span class="line-clamp-2">{attachmentTypeLabel(effectiveMime || 'File')}</span>
+					</div>
+				{/if}
 			</a>
 		</animated.div>
 	{/each}

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-attachment-list.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-attachment-list.svelte
@@ -43,7 +43,9 @@
 		<div
 			class={cn(
 				'relative shrink-0',
-				isImageAttachmentMediaType(mediaType) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+				isImageAttachmentMediaType(mediaType)
+					? 'size-12'
+					: 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
 			)}
 			data-state="uploaded"
 		>
@@ -83,7 +85,9 @@
 		<animated.div
 			class={cn(
 				'relative shrink-0 animate-pulse',
-				isImageAttachmentMediaType(effectiveMime) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+				isImageAttachmentMediaType(effectiveMime)
+					? 'size-12'
+					: 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
 			)}
 			initial={{ scale: 0.75, opacity: 0, y: 10 }}
 			animate={{ scale: 1, opacity: 1, y: 0 }}

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
@@ -6,6 +6,7 @@
 	import type { ModelId } from '../../types.js';
 	import * as FileDropZone from '$lib/components/ui/file-drop-zone';
 	import type { ReasoningEffort } from '$lib/convex/schema.js';
+	import { CHAT_ATTACHMENT_ACCEPT } from '$lib/utils/chat-attachment-types';
 
 	let {
 		class: className,
@@ -68,7 +69,7 @@
 
 <FileDropZone.Root
 	onUpload={promptInputState.onUpload}
-	accept={FileDropZone.ACCEPT_IMAGE}
+	accept={CHAT_ATTACHMENT_ACCEPT}
 	{maxFiles}
 	{fileCount}
 	onFileRejected={(opts) => {

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import { usePromptInput, type ChatPromptAttachment, type OnSubmit } from '../prompt-input/prompt-input.svelte.js';
+	import {
+		usePromptInput,
+		type ChatPromptAttachment,
+		type OnSubmit
+	} from '../prompt-input/prompt-input.svelte.js';
 	import { box } from 'svelte-toolbelt';
 	import type { ModelId } from '../../types.js';
 	import * as FileDropZone from '$lib/components/ui/file-drop-zone';

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import { usePromptInput, type OnSubmit } from '../prompt-input/prompt-input.svelte.js';
+	import { usePromptInput, type ChatPromptAttachment, type OnSubmit } from '../prompt-input/prompt-input.svelte.js';
 	import { box } from 'svelte-toolbelt';
 	import type { ModelId } from '../../types.js';
 	import * as FileDropZone from '$lib/components/ui/file-drop-zone';
@@ -35,7 +35,7 @@
 		value?: string;
 		modelId?: ModelId | null;
 		reasoningEffort?: ReasoningEffort;
-		attachments?: { url: string; key: string; mediaType: string }[];
+		attachments?: ChatPromptAttachment[];
 	} = $props();
 
 	const promptInputState = usePromptInput({

--- a/src/lib/features/chat/components/prompt-input/prompt-input-attachment-button.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-attachment-button.svelte
@@ -2,11 +2,15 @@
 	import * as FileDropZone from '$lib/components/ui/file-drop-zone';
 	import { usePromptInputAttachmentButton } from './prompt-input.svelte.js';
 	import { buttonVariants } from '$lib/components/ui/button/button.svelte';
-	import { RiImageAddLine as ImagePlusIcon } from 'remixicon-svelte';
+	import { RiAttachment2 as AttachmentIcon } from 'remixicon-svelte';
 
 	usePromptInputAttachmentButton();
 </script>
 
-<FileDropZone.Trigger class={buttonVariants({ variant: 'input', size: 'icon' })}>
-	<ImagePlusIcon class="size-4" />
+<FileDropZone.Trigger
+	class={buttonVariants({ variant: 'input', size: 'icon' })}
+	title="Attach images, PDFs, or text files"
+	aria-label="Attach images, PDFs, or text files"
+>
+	<AttachmentIcon class="size-4" />
 </FileDropZone.Trigger>

--- a/src/lib/features/chat/components/prompt-input/prompt-input-attachment-list.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-attachment-list.svelte
@@ -5,11 +5,11 @@
 	import { RiCloseLine as XIcon } from 'remixicon-svelte';
 	import { animated } from 'animated-svelte';
 	import {
-		attachmentTypeLabel,
+		fallbackAttachmentDisplayName,
 		guessMediaTypeFromFileName,
 		isImageAttachmentMediaType
 	} from '$lib/utils/chat-attachment-types';
-	import { RiFileLine as FileIcon } from 'remixicon-svelte';
+	import ChatNonImageAttachmentRow from '$lib/features/chat/chat-non-image-attachment-row.svelte';
 
 	let { class: className, ...rest }: HTMLAttributes<HTMLDivElement> = $props();
 
@@ -32,32 +32,47 @@
 
 <div
 	class={cn(
-		'flex items-center gap-2 h-0 transition-all bg-accent/50 rounded-t-lg px-3 border-transparent',
-		'data-[has-attachments=true]:py-2 data-[has-attachments=true]:h-18 data-[has-attachments=true]:border-b data-[has-attachments=true]:border-border',
+		'flex flex-wrap items-center gap-2 min-h-0 transition-all bg-accent/50 rounded-t-lg px-3 border-transparent',
+		'data-[has-attachments=true]:py-2 data-[has-attachments=true]:min-h-[4.75rem] data-[has-attachments=true]:border-b data-[has-attachments=true]:border-border',
 		className
 	)}
 	data-has-attachments={hasAttachments}
 	{...rest}
 >
-	{#each uploadedAttachments as { url, key, mediaType } (key)}
-		<div class="size-12 rounded-sm border relative overflow-hidden" data-state="uploaded">
+	{#each uploadedAttachments as { url, key, mediaType, fileName } (key)}
+		<div
+			class={cn(
+				'relative shrink-0',
+				isImageAttachmentMediaType(mediaType) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+			)}
+			data-state="uploaded"
+		>
 			<button
 				type="button"
-				class="absolute cursor-pointer bg-background flex items-center justify-center -top-1.5 -right-1.5 rounded-full border border-border size-5 z-10"
+				class="absolute z-20 flex size-5 cursor-pointer items-center justify-center rounded-full border border-border bg-background -top-1.5 -right-1.5"
 				onclick={() => attachmentListState.rootState.deleteAttachment(key)}
 			>
 				<XIcon class="size-3.5" />
 			</button>
-			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+			<a
+				href={url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class={cn(
+					isImageAttachmentMediaType(mediaType)
+						? 'flex size-12 overflow-hidden rounded-md border border-border'
+						: 'block w-full overflow-hidden rounded-xl border border-border'
+				)}
+			>
 				{#if isImageAttachmentMediaType(mediaType)}
-					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+					<img src={url} alt="" class="size-full object-cover" />
 				{:else}
-					<div
-						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
-					>
-						<FileIcon class="size-4 shrink-0 opacity-80" />
-						<span class="line-clamp-2">{attachmentTypeLabel(mediaType)}</span>
-					</div>
+					<ChatNonImageAttachmentRow
+						compact
+						fileName={fileName ?? fallbackAttachmentDisplayName(mediaType)}
+						{mediaType}
+						class="border-0 bg-background/80 shadow-none"
+					/>
 				{/if}
 			</a>
 		</div>
@@ -66,22 +81,34 @@
 		{@const url = URL.createObjectURL(file)}
 		{@const mime = file.type || guessMediaTypeFromFileName(file.name) || ''}
 		<animated.div
-			class="size-12 rounded-sm border relative animate-pulse overflow-hidden"
+			class={cn(
+				'relative shrink-0 animate-pulse',
+				isImageAttachmentMediaType(mime) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+			)}
 			initial={{ scale: 0.75, opacity: 0, y: 10 }}
 			animate={{ scale: 1, opacity: 1, y: 0 }}
 			transition={{ duration: 0.15, delay: 0, timingFunction: 'ease-out' }}
 			data-state="uploading"
 		>
-			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+			<a
+				href={url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class={cn(
+					isImageAttachmentMediaType(mime)
+						? 'flex size-12 overflow-hidden rounded-md border border-border'
+						: 'block w-full overflow-hidden rounded-xl border border-border'
+				)}
+			>
 				{#if isImageAttachmentMediaType(mime)}
-					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+					<img src={url} alt="" class="size-full object-cover" />
 				{:else}
-					<div
-						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
-					>
-						<FileIcon class="size-4 shrink-0 opacity-80" />
-						<span class="line-clamp-2">{attachmentTypeLabel(mime || 'File')}</span>
-					</div>
+					<ChatNonImageAttachmentRow
+						compact
+						fileName={file.name}
+						mediaType={mime || 'application/octet-stream'}
+						class="border-0 bg-background/80 shadow-none"
+					/>
 				{/if}
 			</a>
 		</animated.div>

--- a/src/lib/features/chat/components/prompt-input/prompt-input-attachment-list.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-attachment-list.svelte
@@ -4,6 +4,12 @@
 	import { usePromptInputAttachmentList } from './prompt-input.svelte.js';
 	import { RiCloseLine as XIcon } from 'remixicon-svelte';
 	import { animated } from 'animated-svelte';
+	import {
+		attachmentTypeLabel,
+		guessMediaTypeFromFileName,
+		isImageAttachmentMediaType
+	} from '$lib/utils/chat-attachment-types';
+	import { RiFileLine as FileIcon } from 'remixicon-svelte';
 
 	let { class: className, ...rest }: HTMLAttributes<HTMLDivElement> = $props();
 
@@ -33,31 +39,50 @@
 	data-has-attachments={hasAttachments}
 	{...rest}
 >
-	{#each uploadedAttachments as { url, key } (key)}
-		<div class="size-12 rounded-sm border relative" data-state="uploaded">
+	{#each uploadedAttachments as { url, key, mediaType } (key)}
+		<div class="size-12 rounded-sm border relative overflow-hidden" data-state="uploaded">
 			<button
 				type="button"
-				class="absolute cursor-pointer bg-background flex items-center justify-center -top-1.5 -right-1.5 rounded-full border border-border size-5"
+				class="absolute cursor-pointer bg-background flex items-center justify-center -top-1.5 -right-1.5 rounded-full border border-border size-5 z-10"
 				onclick={() => attachmentListState.rootState.deleteAttachment(key)}
 			>
 				<XIcon class="size-3.5" />
 			</button>
-			<a href={url} target="_blank" rel="noopener noreferrer">
-				<img src={url} alt="Attachment" class="size-full object-cover rounded-sm" />
+			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+				{#if isImageAttachmentMediaType(mediaType)}
+					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+				{:else}
+					<div
+						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
+					>
+						<FileIcon class="size-4 shrink-0 opacity-80" />
+						<span class="line-clamp-2">{attachmentTypeLabel(mediaType)}</span>
+					</div>
+				{/if}
 			</a>
 		</div>
 	{/each}
 	{#each attachmentListState.rootState.uploadingAttachments as [name, file] (name)}
 		{@const url = URL.createObjectURL(file)}
+		{@const mime = file.type || guessMediaTypeFromFileName(file.name) || ''}
 		<animated.div
-			class="size-12 rounded-sm border relative animate-pulse"
+			class="size-12 rounded-sm border relative animate-pulse overflow-hidden"
 			initial={{ scale: 0.75, opacity: 0, y: 10 }}
 			animate={{ scale: 1, opacity: 1, y: 0 }}
 			transition={{ duration: 0.15, delay: 0, timingFunction: 'ease-out' }}
 			data-state="uploading"
 		>
-			<a href={url} target="_blank" rel="noopener noreferrer">
-				<img src={url} alt="Attachment" class="size-full object-cover rounded-sm" />
+			<a href={url} target="_blank" rel="noopener noreferrer" class="size-full flex">
+				{#if isImageAttachmentMediaType(mime)}
+					<img src={url} alt="" class="size-full object-cover rounded-sm" />
+				{:else}
+					<div
+						class="text-muted-foreground bg-muted flex size-full flex-col items-center justify-center gap-0.5 rounded-sm px-0.5 text-[9px] font-medium leading-none text-center"
+					>
+						<FileIcon class="size-4 shrink-0 opacity-80" />
+						<span class="line-clamp-2">{attachmentTypeLabel(mime || 'File')}</span>
+					</div>
+				{/if}
 			</a>
 		</animated.div>
 	{/each}

--- a/src/lib/features/chat/components/prompt-input/prompt-input-attachment-list.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-attachment-list.svelte
@@ -43,7 +43,9 @@
 		<div
 			class={cn(
 				'relative shrink-0',
-				isImageAttachmentMediaType(mediaType) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+				isImageAttachmentMediaType(mediaType)
+					? 'size-12'
+					: 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
 			)}
 			data-state="uploaded"
 		>
@@ -83,7 +85,9 @@
 		<animated.div
 			class={cn(
 				'relative shrink-0 animate-pulse',
-				isImageAttachmentMediaType(mime) ? 'size-12' : 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
+				isImageAttachmentMediaType(mime)
+					? 'size-12'
+					: 'max-w-[min(18rem,calc(100vw-2rem))] min-w-[10rem]'
 			)}
 			initial={{ scale: 0.75, opacity: 0, y: 10 }}
 			animate={{ scale: 1, opacity: 1, y: 0 }}

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import { usePromptInput, type OnSubmit } from './prompt-input.svelte.js';
+	import { usePromptInput, type ChatPromptAttachment, type OnSubmit } from './prompt-input.svelte.js';
 	import { box } from 'svelte-toolbelt';
 	import { RiAlertLine as AlertIcon } from 'remixicon-svelte';
 	import PromptInputBannerContent from './prompt-input-banner-content.svelte';
@@ -39,7 +39,7 @@
 		value?: string;
 		modelId?: ModelId | null;
 		reasoningEffort?: ReasoningEffort;
-		attachments?: { url: string; key: string; mediaType: string }[];
+		attachments?: ChatPromptAttachment[];
 	} = $props();
 
 	const promptInputState = usePromptInput({

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import { usePromptInput, type ChatPromptAttachment, type OnSubmit } from './prompt-input.svelte.js';
+	import {
+		usePromptInput,
+		type ChatPromptAttachment,
+		type OnSubmit
+	} from './prompt-input.svelte.js';
 	import { box } from 'svelte-toolbelt';
 	import { RiAlertLine as AlertIcon } from 'remixicon-svelte';
 	import PromptInputBannerContent from './prompt-input-banner-content.svelte';

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte
@@ -10,6 +10,7 @@
 	import type { ModelId } from '../../types.js';
 	import * as FileDropZone from '$lib/components/ui/file-drop-zone';
 	import type { ReasoningEffort } from '$lib/convex/schema.js';
+	import { CHAT_ATTACHMENT_ACCEPT } from '$lib/utils/chat-attachment-types';
 
 	let {
 		class: className,
@@ -72,7 +73,7 @@
 
 <FileDropZone.Root
 	onUpload={promptInputState.onUpload}
-	accept={FileDropZone.ACCEPT_IMAGE}
+	accept={CHAT_ATTACHMENT_ACCEPT}
 	{maxFiles}
 	{fileCount}
 	onFileRejected={(opts) => {

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte.ts
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte.ts
@@ -8,10 +8,17 @@ import imageCompression from 'browser-image-compression';
 import { IsMobile } from '$lib/hooks/is-mobile.svelte';
 import type { ReasoningEffort } from '$lib/convex/schema';
 
+export type ChatPromptAttachment = {
+	url: string;
+	key: string;
+	mediaType: string;
+	fileName?: string;
+};
+
 export type OnSubmit = (opts: {
 	input: string;
 	modelId: ModelId;
-	attachments: { url: string; key: string; mediaType: string }[];
+	attachments: ChatPromptAttachment[];
 	reasoningEffort: ReasoningEffort;
 }) => Promise<void>;
 
@@ -27,7 +34,7 @@ type PromptInputRootStateOptions = ReadableBoxedValues<{
 		value: string;
 		modelId: ModelId | null;
 		reasoningEffort: ReasoningEffort;
-		attachments: { url: string; key: string; mediaType: string }[];
+		attachments: ChatPromptAttachment[];
 	}>;
 
 class PromptInputRootState {
@@ -44,7 +51,7 @@ class PromptInputRootState {
 
 	async onUpload(files: File[]) {
 		try {
-			// add the pending files
+			const compressedBatch: File[] = [];
 			for (const file of files) {
 				let compressedFile: File = file;
 				if (file.type.startsWith('image/')) {
@@ -55,11 +62,10 @@ class PromptInputRootState {
 				}
 
 				this.uploadingAttachments.set(file.name, compressedFile);
+				compressedBatch.push(compressedFile);
 			}
 
-			const uploadedImages = await this.opts.onUpload.current?.(
-				this.uploadingAttachments.values().toArray()
-			);
+			const uploadedImages = await this.opts.onUpload.current?.(compressedBatch);
 
 			// remove the pending files
 			for (const file of files) {
@@ -68,10 +74,11 @@ class PromptInputRootState {
 
 			this.opts.attachments.current = [
 				...this.opts.attachments.current,
-				...uploadedImages.map((uploadedImage) => ({
+				...uploadedImages.map((uploadedImage, i) => ({
 					url: uploadedImage.url,
 					key: uploadedImage.key,
-					mediaType: uploadedImage.mediaType
+					mediaType: uploadedImage.mediaType,
+					fileName: files[i]?.name
 				}))
 			];
 		} catch (error) {

--- a/src/lib/utils/chat-attachment-types.ts
+++ b/src/lib/utils/chat-attachment-types.ts
@@ -1,3 +1,5 @@
+import { getAttachmentFileExtension } from './media-types';
+
 /**
  * Chat attachments use AI SDK user content parts: {@link ImagePart} and {@link FilePart}.
  * Allowlist common types multimodal models accept; extend as providers add support.
@@ -70,4 +72,10 @@ export function attachmentTypeLabel(mediaType: string): string {
 	if (lower === 'application/json') return 'JSON';
 	const sub = lower.split('/')[1];
 	return sub ? sub.toUpperCase() : 'File';
+}
+
+/** When the original filename is unknown (e.g. legacy rows), show a sensible default. */
+export function fallbackAttachmentDisplayName(mediaType: string): string {
+	const ext = getAttachmentFileExtension(mediaType);
+	return ext ? `attachment${ext}` : 'attachment';
 }

--- a/src/lib/utils/chat-attachment-types.ts
+++ b/src/lib/utils/chat-attachment-types.ts
@@ -1,0 +1,73 @@
+/**
+ * Chat attachments use AI SDK user content parts: {@link ImagePart} and {@link FilePart}.
+ * Allowlist common types multimodal models accept; extend as providers add support.
+ */
+export const CHAT_ATTACHMENT_ACCEPT = [
+	'image/*',
+	'application/pdf',
+	'text/plain',
+	'text/markdown',
+	'text/csv',
+	'application/json',
+	// Browsers often leave `File.type` empty; match by extension.
+	'.jpg',
+	'.jpeg',
+	'.png',
+	'.gif',
+	'.webp',
+	'.svg',
+	'.bmp',
+	'.tif',
+	'.tiff',
+	'.heic',
+	'.heif',
+	'.avif',
+	'.pdf',
+	'.txt',
+	'.md',
+	'.csv',
+	'.json'
+].join(',');
+
+const extensionToMediaType: Record<string, string> = {
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.png': 'image/png',
+	'.gif': 'image/gif',
+	'.webp': 'image/webp',
+	'.svg': 'image/svg+xml',
+	'.bmp': 'image/bmp',
+	'.tif': 'image/tiff',
+	'.tiff': 'image/tiff',
+	'.heic': 'image/heic',
+	'.heif': 'image/heif',
+	'.avif': 'image/avif',
+	'.pdf': 'application/pdf',
+	'.txt': 'text/plain',
+	'.md': 'text/markdown',
+	'.csv': 'text/csv',
+	'.json': 'application/json'
+};
+
+export function guessMediaTypeFromFileName(fileName: string): string | null {
+	const dot = fileName.lastIndexOf('.');
+	if (dot === -1) return null;
+	const ext = fileName.slice(dot).toLowerCase();
+	return extensionToMediaType[ext] ?? null;
+}
+
+export function isImageAttachmentMediaType(mediaType: string): boolean {
+	return mediaType.toLowerCase().trim().startsWith('image/');
+}
+
+export function attachmentTypeLabel(mediaType: string): string {
+	const lower = mediaType.toLowerCase().trim();
+	if (lower.startsWith('image/')) return 'Image';
+	if (lower === 'application/pdf') return 'PDF';
+	if (lower === 'text/plain') return 'Text';
+	if (lower === 'text/markdown') return 'Markdown';
+	if (lower === 'text/csv') return 'CSV';
+	if (lower === 'application/json') return 'JSON';
+	const sub = lower.split('/')[1];
+	return sub ? sub.toUpperCase() : 'File';
+}

--- a/src/lib/utils/media-types.ts
+++ b/src/lib/utils/media-types.ts
@@ -32,3 +32,18 @@ export function getImageFileExtension(
 
 	return imageMediaTypes[normalizedMediaType] ?? null;
 }
+
+const commonNonImageExtensions: Record<string, string> = {
+	'application/pdf': '.pdf',
+	'text/plain': '.txt',
+	'text/markdown': '.md',
+	'text/csv': '.csv',
+	'application/json': '.json'
+};
+
+/** Download filename suffix for any attachment media type (images + other chat files). */
+export function getAttachmentFileExtension(mediaType: string): string | null {
+	const imageExt = getImageFileExtension(mediaType);
+	if (imageExt) return imageExt;
+	return commonNonImageExtensions[mediaType.toLowerCase().trim()] ?? null;
+}

--- a/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/+page.svelte
+++ b/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/+page.svelte
@@ -46,10 +46,9 @@
 	// svelte-ignore state_referenced_locally
 	let query = $state<string>(data.query ?? '');
 
-	const attachmentsList = new PersistedState<{ url: string; key: string; mediaType: string }[]>(
-		'new-chat-attachments',
-		[]
-	);
+	const attachmentsList = new PersistedState<
+		{ url: string; key: string; mediaType: string; fileName?: string }[]
+	>('new-chat-attachments', []);
 
 	const submitOnEnter = $derived(chatLayoutState.userSettingsQuery.data?.submitOnEnter ?? false);
 


### PR DESCRIPTION
Closes #50

Supports images, PDF, plain text, Markdown, CSV, and JSON uploads aligned with AI SDK `ImagePart` / `FilePart`. Updates desktop and mobile attach UX, file-drop extension matching, Convex message mapping, and attachment previews.

Made with [Cursor](https://cursor.com)