### PR TITLE
feat(chat): add stop button to interrupt generation

### DIFF
--- a/src/lib/convex/chats.ts
+++ b/src/lib/convex/chats.ts
@@ -319,6 +319,47 @@ export const updateGenerating = internalMutation({
 	}
 });
 
+export const stopGenerating = mutation({
+	args: {
+		chatId: v.id('chats')
+	},
+	handler: async (ctx, args): Promise<void> => {
+		const user = await ctx.auth.getUserIdentity();
+		if (!user) throw new ConvexError('Unauthorized');
+
+		const chat = await ctx.db.get(args.chatId);
+		if (!chat || chat.userId !== user.subject)
+			throw new ConvexError('Chat not found or you are not authorized to access it');
+
+		if (!chat.generating) return;
+
+		await ctx.db.patch(args.chatId, {
+			stopRequested: true
+		});
+	}
+});
+
+export const isStopRequested = internalQuery({
+	args: {
+		chatId: v.id('chats')
+	},
+	handler: async (ctx, args): Promise<boolean> => {
+		const chat = await ctx.db.get(args.chatId);
+		return chat?.stopRequested ?? false;
+	}
+});
+
+export const clearStopRequested = internalMutation({
+	args: {
+		chatId: v.id('chats')
+	},
+	handler: async (ctx, args): Promise<void> => {
+		await ctx.db.patch(args.chatId, {
+			stopRequested: undefined
+		});
+	}
+});
+
 export const updateGeneratedTitle = internalMutation({
 	args: {
 		chatId: v.id('chats'),

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -383,6 +383,33 @@ ${systemPrompt}
 							}
 						: undefined;
 
+				let wasStopped = false;
+				let stopPollActive = true;
+
+				// Poll for stop requests in the background so the chunk loop below never
+				// has to wait on a database roundtrip. On stop, we flip a flag that the
+				// chunk loop checks; we deliberately don't abort the AI SDK stream because
+				// doing so rejects its internal promises in ways that conflict with the
+				// persistent-text-streaming library's writer cleanup.
+				const stopPoller = (async () => {
+					const intervalMs = 500;
+					while (stopPollActive) {
+						await new Promise((resolve) => setTimeout(resolve, intervalMs));
+						if (!stopPollActive) return;
+						try {
+							const stopRequested = await ctx.runQuery(internal.chats.isStopRequested, {
+								chatId
+							});
+							if (stopRequested) {
+								wasStopped = true;
+								return;
+							}
+						} catch {
+							// Transient query failure — try again on the next tick.
+						}
+					}
+				})();
+
 				if (last.userMessage.chatSettings.supportedParameters?.includes('tools')) {
 					const agent = new ToolLoopAgent({
 						model: openrouter.chat(last.userMessage.chatSettings.modelId),
@@ -434,6 +461,8 @@ ${systemPrompt}
 				const uploadPromises: Promise<void>[] = [];
 
 				for await (const chunk of fullStream) {
+					if (wasStopped) break;
+
 					if (chunk.type === 'text-delta') {
 						openRouterGenId = chunk.id;
 						appender.append({ type: 'text', text: chunk.text });
@@ -478,25 +507,41 @@ ${systemPrompt}
 					}
 				}
 
-				const usage = await totalUsage;
+				// Let the background poller exit.
+				stopPollActive = false;
+				await stopPoller;
 
-				// wait for uploads to complete
+				// Only await usage when the stream completed naturally — the promise
+				// never resolves once we've broken out early.
+				let usage: Awaited<typeof totalUsage> | null = null;
+				if (!wasStopped) {
+					usage = await totalUsage;
+				}
+
 				if (uploadPromises.length > 0) {
 					await Promise.all(uploadPromises);
 				}
 
-				const repackedContent = repackStream(content).expect('Failed to repack stream');
+				// If the stream was aborted before any content was emitted, `content` is
+				// empty and the protocol-versioned repack will fail — fall back to empty
+				// so we still clear `generating` on the chat.
+				const repackResult = content.length > 0 ? repackStream(content) : null;
+				const repackedContent = repackResult?.isOk() ? repackResult.value : '';
 
 				await ctx.runMutation(internal.messages.updateMessageContent, {
 					messageId: last.assistantMessage._id,
 					content: repackedContent,
 					meta: {
 						generationId: openRouterGenId,
-						tokenUsage: usage.totalTokens,
-						outputTokens: usage.outputTokens,
-						inputTokens: usage.inputTokens
+						tokenUsage: usage?.totalTokens,
+						outputTokens: usage?.outputTokens,
+						inputTokens: usage?.inputTokens
 					}
 				});
+
+				if (wasStopped) {
+					await ctx.runMutation(internal.chats.clearStopRequested, { chatId });
+				}
 
 				if (openRouterGenId) {
 					// we wait long enough for the gen to propagate to openrouter
@@ -614,7 +659,8 @@ export const startGenerating = internalMutation({
 				}
 			}),
 			ctx.db.patch(message.chatId, {
-				generating: true
+				generating: true,
+				stopRequested: undefined
 			})
 		]);
 	}

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -86,6 +86,7 @@ export default defineSchema({
 	chats: defineTable({
 		generating: v.boolean(),
 		generatingTitle: v.optional(v.boolean()),
+		stopRequested: v.optional(v.boolean()),
 		userId: v.string(),
 		title: v.string(),
 		updatedAt: v.number(),

--- a/src/lib/features/chat/chat-view.svelte
+++ b/src/lib/features/chat/chat-view.svelte
@@ -217,6 +217,7 @@
 							autoScroll.scrollToBottom(false, 'instant');
 							return chatLayoutState.handleSubmit(opts);
 						}}
+						onStop={chatLayoutState.handleStop}
 						onUpload={chatAttachmentUploader.uploadMany}
 						onDeleteAttachment={chatAttachmentUploader.deleteAttachment}
 						bind:attachments={attachmentsList.current}
@@ -289,6 +290,7 @@
 							autoScroll.scrollToBottom(false, 'instant');
 							return chatLayoutState.handleSubmit(opts);
 						}}
+						onStop={chatLayoutState.handleStop}
 						onUpload={chatAttachmentUploader.uploadMany}
 						onDeleteAttachment={chatAttachmentUploader.deleteAttachment}
 						bind:attachments={attachmentsList.current}

--- a/src/lib/features/chat/chat.svelte.ts
+++ b/src/lib/features/chat/chat.svelte.ts
@@ -58,6 +58,7 @@ class ChatLayoutState {
 		this.localApiKey = useLocalApiKey();
 
 		this.handleSubmit = this.handleSubmit.bind(this);
+		this.handleStop = this.handleStop.bind(this);
 	}
 
 	get isAdvancedMode() {
@@ -132,6 +133,13 @@ class ChatLayoutState {
 		return (
 			this.localApiKey.current ?? this.apiKeysQuery.current?.key ?? this.opts.apiKey?.key ?? null
 		);
+	}
+
+	async handleStop() {
+		if (!this.chatId) return;
+		await this.client.mutation(api.chats.stopGenerating, {
+			chatId: this.chatId
+		});
 	}
 
 	handleSubmit: OnSubmit = async ({ input, modelId, attachments, reasoningEffort }) => {

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-submit.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-submit.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button, type ButtonElementProps } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
-	import { RiSendPlaneLine as SendIcon } from 'remixicon-svelte';
+	import { RiSendPlaneLine as SendIcon, RiStopLargeLine as StopIcon } from 'remixicon-svelte';
 	import { usePromptInputSubmit } from '../prompt-input/prompt-input.svelte.js';
 	import { box } from 'svelte-toolbelt';
 
@@ -33,6 +33,8 @@
 >
 	{#if children}
 		{@render children()}
+	{:else if submitState.generating}
+		<StopIcon />
 	{:else if !submitState.rootState.loading}
 		<SendIcon class="group-data-[loading=true]:hidden" />
 	{/if}

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
@@ -16,6 +16,7 @@
 		class: className,
 		children,
 		onSubmit,
+		onStop,
 		submitOnEnter = false,
 		optimisticClear = true,
 		value = $bindable(''),
@@ -28,6 +29,7 @@
 		...rest
 	}: HTMLAttributes<HTMLDivElement> & {
 		onSubmit: OnSubmit;
+		onStop?: () => void | Promise<void>;
 		onUpload: (files: File[]) => Promise<{ url: string; key: string; mediaType: string }[]>;
 		onDeleteAttachment: (key: string) => Promise<void>;
 		generating?: boolean;
@@ -44,6 +46,7 @@
 
 	const promptInputState = usePromptInput({
 		onSubmit: box.with(() => onSubmit),
+		onStop: box.with(() => onStop),
 		onUpload: box.with(() => onUpload),
 		onDeleteAttachment: box.with(() => onDeleteAttachment),
 		submitOnEnter: box.with(() => submitOnEnter),

--- a/src/lib/features/chat/components/prompt-input/prompt-input-submit.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-submit.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button, type ButtonElementProps } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
-	import { RiSendPlaneLine as SendIcon } from 'remixicon-svelte';
+	import { RiSendPlaneLine as SendIcon, RiStopLargeLine as StopIcon } from 'remixicon-svelte';
 	import { usePromptInputSubmit } from './prompt-input.svelte.js';
 	import { box } from 'svelte-toolbelt';
 
@@ -30,6 +30,8 @@
 >
 	{#if children}
 		{@render children()}
+	{:else if submitState.generating}
+		<StopIcon />
 	{:else if !submitState.rootState.loading}
 		<SendIcon class="group-data-[loading=true]:hidden" />
 	{/if}

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte
@@ -20,6 +20,7 @@
 		class: className,
 		children,
 		onSubmit,
+		onStop,
 		submitOnEnter = false,
 		optimisticClear = true,
 		value = $bindable(''),
@@ -32,6 +33,7 @@
 		...rest
 	}: HTMLAttributes<HTMLDivElement> & {
 		onSubmit: OnSubmit;
+		onStop?: () => void | Promise<void>;
 		onUpload: (files: File[]) => Promise<{ url: string; key: string; mediaType: string }[]>;
 		onDeleteAttachment: (key: string) => Promise<void>;
 		generating?: boolean;
@@ -48,6 +50,7 @@
 
 	const promptInputState = usePromptInput({
 		onSubmit: box.with(() => onSubmit),
+		onStop: box.with(() => onStop),
 		onUpload: box.with(() => onUpload),
 		onDeleteAttachment: box.with(() => onDeleteAttachment),
 		submitOnEnter: box.with(() => submitOnEnter),

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte.ts
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte.ts
@@ -24,6 +24,7 @@ export type OnSubmit = (opts: {
 
 type PromptInputRootStateOptions = ReadableBoxedValues<{
 	onSubmit: OnSubmit;
+	onStop?: () => void | Promise<void>;
 	submitOnEnter?: boolean;
 	optimisticClear?: boolean;
 	generating: boolean;
@@ -123,6 +124,17 @@ class PromptInputRootState {
 			this.loading = false;
 		}
 	}
+
+	async stop() {
+		try {
+			await this.opts.onStop?.current?.();
+		} catch (error) {
+			this.error =
+				error instanceof Error
+					? error.message
+					: 'An unknown error occurred while trying to stop generation.';
+		}
+	}
 }
 
 type PromptInputTextareaStateOptions = ReadableBoxedValues<{
@@ -190,20 +202,31 @@ class PromptInputSubmitState {
 	) {}
 
 	onclick(e: Parameters<NonNullable<ButtonElementProps['onclick']>>[0]) {
-		this.rootState.submit(this.rootState.opts.value.current);
+		if (this.rootState.opts.generating.current) {
+			this.rootState.stop();
+		} else {
+			this.rootState.submit(this.rootState.opts.value.current);
+		}
 		this.opts.onclick?.current?.(e);
 	}
 
-	props = $derived.by(() => ({
-		onclick: this.onclick.bind(this),
-		disabled:
-			(this.rootState.opts.value.current.trim().length === 0 &&
-				!this.rootState.opts.generating.current) ||
-			this.rootState.uploadingAttachments.size > 0 ||
-			this.opts.disabled.current,
-		loading: this.rootState.loading,
-		'data-generating': this.rootState.opts.generating.current
-	}));
+	props = $derived.by(() => {
+		const generating = this.rootState.opts.generating.current;
+		return {
+			onclick: this.onclick.bind(this),
+			disabled:
+				(this.rootState.opts.value.current.trim().length === 0 && !generating) ||
+				this.rootState.uploadingAttachments.size > 0 ||
+				this.opts.disabled.current,
+			loading: this.rootState.loading && !generating,
+			'data-generating': generating,
+			'aria-label': generating ? 'Stop generation' : 'Send message'
+		};
+	});
+
+	get generating() {
+		return this.rootState.opts.generating.current;
+	}
 }
 
 type PromptInputBannerStateOptions = ReadableBoxedValues<{


### PR DESCRIPTION
## Summary
- While a response is streaming, the submit button becomes a stop button (square icon) that cancels the in-flight generation.
- Cancellation is driven by a `stopRequested` flag on the chat doc, set by a new `stopGenerating` public mutation and polled in the background by the server-side stream loop.
- On stop, the loop breaks cleanly, saves whatever content was streamed so far, clears the flag, and flips `generating` back to false so the UI returns to the send state.

## Implementation notes
- **Schema** — added `stopRequested?: boolean` to the `chats` table; cleared at the start of each generation in `startGenerating` so stale flags never persist.
- **Server** — `messages.streamMessage` runs a background poller alongside the chunk loop so polling never stalls a chunk. I deliberately *do not* pass an `AbortSignal` to the AI SDK: aborting rejected internal promises on `streamResult` (`totalUsage`, etc.) which in turn broke the `persistent-text-streaming` library's writer cleanup. The flag-based break lets the stream finalize normally and the response close without errors. Trade-off: the upstream model call finishes in the background; we just stop consuming it.
- **Partial content safety** — empty/malformed content (stopping before any tokens arrive) previously threw from `repackStream().expect(...)`, which bubbled past the outer catch and left `generating` stuck. Now we guard with an `isOk()` check and fall back to saving empty content so `updateMessageContent` always runs.
- **Client** — `PromptInputRootState` gained an `onStop` option and a `stop()` method; `PromptInputSubmitState.onclick` dispatches to `stop()` when `generating`. The disabled gate opens up when generating so the stop button stays clickable on an empty input. `chatLayoutState.handleStop` calls the new mutation.
- **Icon** — filled square `RiStopLargeLine` from `remixicon-svelte`, swapped in on both desktop and mobile submit buttons.

## Test plan
- [ ] Start a streaming response, click stop mid-stream — verify generation halts and partial content is preserved as the final assistant message.
- [ ] Start a streaming response, click stop immediately (before any tokens) — verify button returns to send state (message will show "Error generating message" which is expected for now).
- [ ] Let a response complete naturally — verify no regression: content saves, usage tokens recorded, cost lookup still scheduled.
- [ ] Verify on mobile viewport — stop icon replaces send icon in the mobile submit button.
- [ ] Confirm no `Uncaught AbortError` / "stream is not in a state that permits close" errors appear in the Convex dev log when stopping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)