### PR TITLE
feat(chat): show cancelling indicator while stream stops

### DIFF
--- a/src/lib/features/chat/chat-view.svelte
+++ b/src/lib/features/chat/chat-view.svelte
@@ -212,6 +212,7 @@
 						bind:modelId={modelId.current}
 						bind:reasoningEffort={reasoningEffort.current}
 						generating={chatViewState.chatQuery.data?.generating}
+						cancelling={chatViewState.chatQuery.data?.stopRequested}
 						{submitOnEnter}
 						onSubmit={(opts) => {
 							autoScroll.scrollToBottom(false, 'instant');
@@ -285,6 +286,7 @@
 						bind:modelId={modelId.current}
 						bind:reasoningEffort={reasoningEffort.current}
 						generating={chatViewState.chatQuery.data?.generating}
+						cancelling={chatViewState.chatQuery.data?.stopRequested}
 						{submitOnEnter}
 						onSubmit={(opts) => {
 							autoScroll.scrollToBottom(false, 'instant');

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-submit.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile-submit.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button, type ButtonElementProps } from '$lib/components/ui/button';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { cn } from '$lib/utils';
 	import { RiSendPlaneLine as SendIcon, RiStopLargeLine as StopIcon } from 'remixicon-svelte';
 	import { usePromptInputSubmit } from '../prompt-input/prompt-input.svelte.js';
@@ -33,6 +34,9 @@
 >
 	{#if children}
 		{@render children()}
+	{:else if submitState.cancelling}
+		<Spinner />
+		<span class="sr-only">Cancelling</span>
 	{:else if submitState.generating}
 		<StopIcon />
 	{:else if !submitState.rootState.loading}

--- a/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
+++ b/src/lib/features/chat/components/prompt-input-mobile/prompt-input-mobile.svelte
@@ -23,6 +23,7 @@
 		modelId = $bindable(null),
 		reasoningEffort = $bindable('default'),
 		generating = false,
+		cancelling = false,
 		onUpload,
 		onDeleteAttachment,
 		attachments = $bindable([]),
@@ -33,6 +34,7 @@
 		onUpload: (files: File[]) => Promise<{ url: string; key: string; mediaType: string }[]>;
 		onDeleteAttachment: (key: string) => Promise<void>;
 		generating?: boolean;
+		cancelling?: boolean;
 		/**
 		 * Whether to submit the form on enter. Otherwise the form will be submitted on Ctrl/Cmd+Enter.
 		 */
@@ -51,6 +53,7 @@
 		onDeleteAttachment: box.with(() => onDeleteAttachment),
 		submitOnEnter: box.with(() => submitOnEnter),
 		generating: box.with(() => generating),
+		cancelling: box.with(() => cancelling),
 		value: box.with(
 			() => value,
 			(v) => (value = v)

--- a/src/lib/features/chat/components/prompt-input/prompt-input-submit.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-submit.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button, type ButtonElementProps } from '$lib/components/ui/button';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { cn } from '$lib/utils';
 	import { RiSendPlaneLine as SendIcon, RiStopLargeLine as StopIcon } from 'remixicon-svelte';
 	import { usePromptInputSubmit } from './prompt-input.svelte.js';
@@ -30,6 +31,9 @@
 >
 	{#if children}
 		{@render children()}
+	{:else if submitState.cancelling}
+		<Spinner />
+		<span class="sr-only">Cancelling</span>
 	{:else if submitState.generating}
 		<StopIcon />
 	{:else if !submitState.rootState.loading}

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte
@@ -27,6 +27,7 @@
 		modelId = $bindable(null),
 		reasoningEffort = $bindable('default'),
 		generating = false,
+		cancelling = false,
 		onUpload,
 		onDeleteAttachment,
 		attachments = $bindable([]),
@@ -37,6 +38,7 @@
 		onUpload: (files: File[]) => Promise<{ url: string; key: string; mediaType: string }[]>;
 		onDeleteAttachment: (key: string) => Promise<void>;
 		generating?: boolean;
+		cancelling?: boolean;
 		/**
 		 * Whether to submit the form on enter. Otherwise the form will be submitted on Ctrl/Cmd+Enter.
 		 */
@@ -55,6 +57,7 @@
 		onDeleteAttachment: box.with(() => onDeleteAttachment),
 		submitOnEnter: box.with(() => submitOnEnter),
 		generating: box.with(() => generating),
+		cancelling: box.with(() => cancelling),
 		value: box.with(
 			() => value,
 			(v) => (value = v)

--- a/src/lib/features/chat/components/prompt-input/prompt-input.svelte.ts
+++ b/src/lib/features/chat/components/prompt-input/prompt-input.svelte.ts
@@ -28,6 +28,7 @@ type PromptInputRootStateOptions = ReadableBoxedValues<{
 	submitOnEnter?: boolean;
 	optimisticClear?: boolean;
 	generating: boolean;
+	cancelling?: boolean;
 	onUpload: (files: File[]) => Promise<{ url: string; key: string; mediaType: string }[]>;
 	onDeleteAttachment: (key: string) => Promise<void>;
 }> &
@@ -41,6 +42,7 @@ type PromptInputRootStateOptions = ReadableBoxedValues<{
 class PromptInputRootState {
 	loading = $state(false);
 	error = $state<string | null>(null);
+	optimisticCancelling = $state(false);
 	uploadingAttachments: Map<string, File> = new SvelteMap();
 	textAreaRef = $state<HTMLTextAreaElement | null>(null);
 	isMobile: IsMobile;
@@ -48,6 +50,20 @@ class PromptInputRootState {
 	constructor(readonly opts: PromptInputRootStateOptions) {
 		this.onUpload = this.onUpload.bind(this);
 		this.isMobile = new IsMobile();
+
+		watch(
+			() => this.opts.generating.current,
+			(generating) => {
+				if (!generating) this.optimisticCancelling = false;
+			}
+		);
+	}
+
+	get cancelling() {
+		return (
+			this.opts.generating.current &&
+			(this.optimisticCancelling || (this.opts.cancelling?.current ?? false))
+		);
 	}
 
 	async onUpload(files: File[]) {
@@ -127,8 +143,10 @@ class PromptInputRootState {
 
 	async stop() {
 		try {
+			this.optimisticCancelling = true;
 			await this.opts.onStop?.current?.();
 		} catch (error) {
+			this.optimisticCancelling = false;
 			this.error =
 				error instanceof Error
 					? error.message
@@ -202,6 +220,7 @@ class PromptInputSubmitState {
 	) {}
 
 	onclick(e: Parameters<NonNullable<ButtonElementProps['onclick']>>[0]) {
+		if (this.rootState.cancelling) return;
 		if (this.rootState.opts.generating.current) {
 			this.rootState.stop();
 		} else {
@@ -212,20 +231,31 @@ class PromptInputSubmitState {
 
 	props = $derived.by(() => {
 		const generating = this.rootState.opts.generating.current;
+		const cancelling = this.rootState.cancelling;
 		return {
 			onclick: this.onclick.bind(this),
 			disabled:
 				(this.rootState.opts.value.current.trim().length === 0 && !generating) ||
 				this.rootState.uploadingAttachments.size > 0 ||
+				cancelling ||
 				this.opts.disabled.current,
 			loading: this.rootState.loading && !generating,
 			'data-generating': generating,
-			'aria-label': generating ? 'Stop generation' : 'Send message'
+			'data-cancelling': cancelling,
+			'aria-label': cancelling
+				? 'Cancelling generation'
+				: generating
+					? 'Stop generation'
+					: 'Send message'
 		};
 	});
 
 	get generating() {
 		return this.rootState.opts.generating.current;
+	}
+
+	get cancelling() {
+		return this.rootState.cancelling;
 	}
 }
 


### PR DESCRIPTION
When the user clicks stop, the stream can take a moment to actually
halt. Surface a spinner on the submit button and disable clicks until
generation ends so the user sees their cancel was received.

https://claude.ai/code/session_012n1qG8bXSdD8azVpES5Qos