### PR TITLE
Add message editing functionality to chat

### DIFF
--- a/src/lib/components/ui/split-button/index.ts
+++ b/src/lib/components/ui/split-button/index.ts
@@ -1,0 +1,26 @@
+import Root from './split-button.svelte';
+import Primary from './split-button-primary.svelte';
+import Trigger from './split-button-trigger.svelte';
+import { Content, Item, Separator, Group, Label, Shortcut } from '$lib/components/ui/dropdown-menu';
+
+export {
+	Root,
+	Primary,
+	Trigger,
+	Content,
+	Item,
+	Separator,
+	Group,
+	Label,
+	Shortcut,
+	//
+	Root as SplitButton,
+	Primary as SplitButtonPrimary,
+	Trigger as SplitButtonTrigger,
+	Content as SplitButtonContent,
+	Item as SplitButtonItem,
+	Separator as SplitButtonSeparator,
+	Group as SplitButtonGroup,
+	Label as SplitButtonLabel,
+	Shortcut as SplitButtonShortcut
+};

--- a/src/lib/components/ui/split-button/split-button-primary.svelte
+++ b/src/lib/components/ui/split-button/split-button-primary.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { Button, type ButtonProps } from '$lib/components/ui/button';
+	import { cn } from '$lib/utils.js';
+
+	let { class: className, children, ...rest }: ButtonProps = $props();
+</script>
+
+<Button data-slot="split-button-primary" class={cn('rounded-r-none', className)} {...rest}>
+	{@render children?.()}
+</Button>

--- a/src/lib/components/ui/split-button/split-button-trigger.svelte
+++ b/src/lib/components/ui/split-button/split-button-trigger.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { Button, type ButtonProps, type ButtonVariant } from '$lib/components/ui/button';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import { cn } from '$lib/utils.js';
+	import { RiArrowDownSLine as ChevronDownIcon } from 'remixicon-svelte';
+
+	let {
+		class: className,
+		children,
+		variant = 'default',
+		size = 'icon',
+		'aria-label': ariaLabel = 'Open menu',
+		...rest
+	}: ButtonProps & { variant?: ButtonVariant; 'aria-label'?: string } = $props();
+</script>
+
+<DropdownMenu.Trigger>
+	{#snippet child({ props })}
+		<Button
+			data-slot="split-button-trigger"
+			class={cn('rounded-l-none border-l border-l-black/10 dark:border-l-white/10', className)}
+			{variant}
+			{size}
+			aria-label={ariaLabel}
+			{...props}
+			{...rest}
+		>
+			{#if children}
+				{@render children()}
+			{:else}
+				<ChevronDownIcon />
+			{/if}
+		</Button>
+	{/snippet}
+</DropdownMenu.Trigger>

--- a/src/lib/components/ui/split-button/split-button.svelte
+++ b/src/lib/components/ui/split-button/split-button.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		class: className,
+		children,
+		open = $bindable(false),
+		...rest
+	}: HTMLAttributes<HTMLDivElement> & { open?: boolean } = $props();
+</script>
+
+<DropdownMenu.Root bind:open>
+	<div data-slot="split-button" class={cn('inline-flex items-stretch', className)} {...rest}>
+		{@render children?.()}
+	</div>
+</DropdownMenu.Root>

--- a/src/lib/convex/chats.ts
+++ b/src/lib/convex/chats.ts
@@ -383,7 +383,18 @@ export const branchFromMessage = mutation({
 				supportedParameters: v.array(v.string()),
 				inputModalities: v.array(v.string()),
 				outputModalities: v.array(v.string()),
-				reasoningEffort: v.optional(ReasoningEffort)
+				reasoningEffort: v.optional(ReasoningEffort),
+				content: v.optional(v.string()),
+				attachments: v.optional(
+					v.array(
+						v.object({
+							url: v.string(),
+							key: v.string(),
+							mediaType: v.string(),
+							fileName: v.optional(v.string())
+						})
+					)
+				)
 			}),
 			v.object({
 				_id: v.id('messages'),
@@ -439,6 +450,8 @@ export const branchFromMessage = mutation({
 		// copy over the messages with attachments
 		await Promise.all(
 			messages.map(async (m, i) => {
+				const isEditedLastUserMessage =
+					m._id === args.message._id && args.message.role === 'user' && i === messages.length - 1;
 				const ogAttachments = relatedAttachments.filter((a) => a.messageId === m._id);
 				let newMessageId: Id<'messages'>;
 				if (m.role === 'user') {
@@ -446,12 +459,15 @@ export const branchFromMessage = mutation({
 						userId: user.subject,
 						role: 'user',
 						chatId: newChatId,
-						content: m.content,
+						content:
+							isEditedLastUserMessage &&
+							args.message.role === 'user' &&
+							args.message.content !== undefined
+								? args.message.content
+								: m.content,
 						chatSettings:
 							// only override the chat settings for the last user message
-							m._id === args.message._id &&
-							args.message.role === 'user' &&
-							i === messages.length - 1
+							isEditedLastUserMessage && args.message.role === 'user'
 								? {
 										modelId: args.message.modelId,
 										supportedParameters: args.message.supportedParameters,
@@ -472,19 +488,40 @@ export const branchFromMessage = mutation({
 						error: m.error
 					});
 				}
-				// copy over attachments
-				await Promise.all(
-					ogAttachments.map((a) =>
-						ctx.db.insert('chatAttachments', {
-							messageId: newMessageId,
-							chatId: newChatId,
-							userId: user.subject,
-							key: a.key,
-							mediaType: a.mediaType,
-							...(a.fileName !== undefined ? { fileName: a.fileName } : {})
-						})
-					)
-				);
+
+				// If this is the edited last user message and the caller supplied new
+				// attachments, use those instead of the original message's attachments.
+				if (
+					isEditedLastUserMessage &&
+					args.message.role === 'user' &&
+					args.message.attachments !== undefined
+				) {
+					await Promise.all(
+						args.message.attachments.map((a) =>
+							ctx.db.insert('chatAttachments', {
+								messageId: newMessageId,
+								chatId: newChatId,
+								userId: user.subject,
+								key: a.key,
+								mediaType: a.mediaType,
+								...(a.fileName !== undefined ? { fileName: a.fileName } : {})
+							})
+						)
+					);
+				} else {
+					await Promise.all(
+						ogAttachments.map((a) =>
+							ctx.db.insert('chatAttachments', {
+								messageId: newMessageId,
+								chatId: newChatId,
+								userId: user.subject,
+								key: a.key,
+								mediaType: a.mediaType,
+								...(a.fileName !== undefined ? { fileName: a.fileName } : {})
+							})
+						)
+					);
+				}
 			})
 		);
 

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -212,8 +212,7 @@ export const editMessage = mutation({
 
 		const sourceMessage = await ctx.db.get(args.messageId);
 		if (!sourceMessage) throw new ConvexError('Message not found');
-		if (sourceMessage.role !== 'user')
-			throw new ConvexError('Only user messages can be edited');
+		if (sourceMessage.role !== 'user') throw new ConvexError('Only user messages can be edited');
 		if (sourceMessage.userId !== user.subject) throw new ConvexError('Unauthorized');
 
 		const chat = await ctx.db.get(sourceMessage.chatId);

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -195,6 +195,127 @@ export const create = mutation({
 	}
 });
 
+export const editMessage = mutation({
+	args: {
+		messageId: v.id('messages'),
+		prompt: Prompt,
+		apiKey: v.string()
+	},
+	handler: async (
+		ctx,
+		args
+	): Promise<{
+		assistantMessageId: Id<'messages'>;
+	}> => {
+		const user = await ctx.auth.getUserIdentity();
+		if (!user) throw new ConvexError('Unauthorized');
+
+		const sourceMessage = await ctx.db.get(args.messageId);
+		if (!sourceMessage) throw new ConvexError('Message not found');
+		if (sourceMessage.role !== 'user')
+			throw new ConvexError('Only user messages can be edited');
+		if (sourceMessage.userId !== user.subject) throw new ConvexError('Unauthorized');
+
+		const chat = await ctx.db.get(sourceMessage.chatId);
+		if (!chat) throw new ConvexError('Chat not found');
+		if (chat.userId !== user.subject) throw new ConvexError('Unauthorized');
+		if (chat.generating)
+			throw new ConvexError('Stop the current response before editing a message');
+
+		const isFreeUser = args.apiKey.trim() === '';
+
+		if (isFreeUser && !args.prompt.modelId.endsWith(':free')) {
+			throw new ConvexError('API key is required for non-free models');
+		}
+
+		if (isFreeUser) {
+			const status = await rateLimiter.limit(ctx, 'freeMessages', { key: user.subject });
+			if (!status.ok) {
+				throw new ConvexError(
+					`Rate limit exceeded. Try again in ${formatTimeUntil(status.retryAfter)}`
+				);
+			}
+		}
+
+		const allMessages = await ctx.db
+			.query('messages')
+			.withIndex('by_chat', (q) => q.eq('chatId', sourceMessage.chatId))
+			.collect();
+
+		// delete everything after the edited message (and the old attachments for it)
+		const messagesToRemove = allMessages.filter(
+			(m) => m._creationTime > sourceMessage._creationTime
+		);
+
+		for (const m of messagesToRemove) {
+			const attachments = await ctx.db
+				.query('chatAttachments')
+				.withIndex('by_message', (q) => q.eq('messageId', m._id))
+				.collect();
+			for (const a of attachments) {
+				await ctx.db.delete(a._id);
+			}
+			await ctx.db.delete(m._id);
+		}
+
+		// replace attachments for the edited message
+		const existingAttachments = await ctx.db
+			.query('chatAttachments')
+			.withIndex('by_message', (q) => q.eq('messageId', args.messageId))
+			.collect();
+		for (const a of existingAttachments) {
+			await ctx.db.delete(a._id);
+		}
+
+		await ctx.db.patch(args.messageId, {
+			content: args.prompt.input,
+			chatSettings: {
+				modelId: args.prompt.modelId,
+				supportedParameters: args.prompt.supportedParameters,
+				inputModalities: args.prompt.inputModalities,
+				outputModalities: args.prompt.outputModalities,
+				reasoningEffort: args.prompt.reasoningEffort
+			}
+		});
+
+		if (args.prompt.attachments && args.prompt.attachments.length > 0) {
+			await Promise.all(
+				args.prompt.attachments.map(async (attachment) => {
+					await ctx.runMutation(internal.chatAttachments.create, {
+						chatId: sourceMessage.chatId,
+						messageId: args.messageId,
+						key: attachment.key,
+						userId: user.subject,
+						mediaType: attachment.mediaType,
+						fileName: attachment.fileName
+					});
+				})
+			);
+		}
+
+		const isImageModel =
+			args.prompt.outputModalities.length === 1 && args.prompt.outputModalities[0] === 'image';
+
+		const streamId = await persistentTextStreaming.createStream(ctx);
+		const assistantMessageId = await ctx.db.insert('messages', {
+			chatId: sourceMessage.chatId,
+			userId: user.subject,
+			role: 'assistant',
+			streamId,
+			meta: {
+				modelId: args.prompt.modelId,
+				imageGen: isImageModel
+			}
+		});
+
+		await ctx.db.patch(sourceMessage.chatId, {
+			updatedAt: Date.now()
+		});
+
+		return { assistantMessageId };
+	}
+});
+
 export const getChatBody = query({
 	args: {
 		streamId: StreamIdValidator

--- a/src/lib/features/chat/chat-message-edit.svelte
+++ b/src/lib/features/chat/chat-message-edit.svelte
@@ -104,7 +104,7 @@
 					{/if}
 				</div>
 				<div class="flex items-center gap-2">
-					<Button variant="ghost" size="sm" onclick={onDone}>Cancel</Button>
+					<Button variant="ghost" onclick={onDone}>Cancel</Button>
 					<PromptInput.Submit />
 				</div>
 			</PromptInput.Footer>

--- a/src/lib/features/chat/chat-message-edit.svelte
+++ b/src/lib/features/chat/chat-message-edit.svelte
@@ -9,7 +9,8 @@
 	import {
 		RiAlertLine as AlertIcon,
 		RiSendPlaneLine as SendIcon,
-		RiGitBranchLine as SplitIcon
+		RiGitBranchLine as SplitIcon,
+		RiCheckLine as CheckIcon
 	} from 'remixicon-svelte';
 	import { useChatLayout } from './chat.svelte.js';
 	import type { Id } from '$lib/convex/_generated/dataModel';
@@ -66,13 +67,10 @@
 		attachments: ChatPromptAttachment[];
 		reasoningEffort: ReasoningEffort;
 	}) {
-		const intent = submitIntent;
-		// reset intent so future Enter-key submits default to 'edit'
-		submitIntent = 'edit';
-		if (intent !== 'branch') onBeforeSubmit?.();
-		if (intent === 'branch') {
+		if (submitIntent === 'branch') {
 			await chatLayoutState.handleBranchEdit(messageId, opts);
 		} else {
+			onBeforeSubmit?.();
 			await chatLayoutState.handleEdit(messageId, opts);
 		}
 		onDone();
@@ -119,27 +117,30 @@
 				</div>
 				<div class="flex items-center gap-2">
 					<Button variant="ghost" onclick={onDone}>Cancel</Button>
-					<PromptInput.SplitSubmit>
-						{#snippet children({ submit })}
-							<SplitButton.Item
-								onSelect={() => {
-									submitIntent = 'branch';
-									submit();
-								}}
-							>
+					<PromptInput.SplitSubmit
+						aria-label={submitIntent === 'branch' ? 'Branch and send' : 'Send message'}
+					>
+						{#snippet primaryIcon()}
+							{#if submitIntent === 'branch'}
 								<SplitIcon />
-								Branch and send
-							</SplitButton.Item>
-							<SplitButton.Item
-								onSelect={() => {
-									submitIntent = 'edit';
-									submit();
-								}}
-							>
+							{:else}
 								<SendIcon />
-								Send
-							</SplitButton.Item>
+							{/if}
 						{/snippet}
+						<SplitButton.Item onSelect={() => (submitIntent = 'edit')}>
+							<SendIcon />
+							<span class="flex-1">Send</span>
+							{#if submitIntent === 'edit'}
+								<CheckIcon class="size-4" />
+							{/if}
+						</SplitButton.Item>
+						<SplitButton.Item onSelect={() => (submitIntent = 'branch')}>
+							<SplitIcon />
+							<span class="flex-1">Branch and send</span>
+							{#if submitIntent === 'branch'}
+								<CheckIcon class="size-4" />
+							{/if}
+						</SplitButton.Item>
 					</PromptInput.SplitSubmit>
 				</div>
 			</PromptInput.Footer>

--- a/src/lib/features/chat/chat-message-edit.svelte
+++ b/src/lib/features/chat/chat-message-edit.svelte
@@ -1,11 +1,16 @@
 <!-- svelte-ignore state_referenced_locally -->
 <script lang="ts">
 	import * as PromptInput from '$lib/features/chat/components/prompt-input';
+	import * as SplitButton from '$lib/components/ui/split-button';
 	import ModelPickerBasic from '$lib/features/models/components/models-picker-basic.svelte';
 	import ModelPickerAdvanced from '$lib/features/models/components/models-picker-advanced.svelte';
 	import ReasoningEffortPicker from './components/reasoning-effort-picker.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { RiAlertLine as AlertIcon } from 'remixicon-svelte';
+	import {
+		RiAlertLine as AlertIcon,
+		RiSendPlaneLine as SendIcon,
+		RiGitBranchLine as SplitIcon
+	} from 'remixicon-svelte';
 	import { useChatLayout } from './chat.svelte.js';
 	import type { Id } from '$lib/convex/_generated/dataModel';
 	import type { ModelId } from './types.js';
@@ -53,14 +58,23 @@
 		return attachments.length > 0 && model ? !supportsImages(model) : false;
 	});
 
+	let submitIntent = $state<'edit' | 'branch'>('edit');
+
 	async function handleSubmit(opts: {
 		input: string;
 		modelId: ModelId;
 		attachments: ChatPromptAttachment[];
 		reasoningEffort: ReasoningEffort;
 	}) {
-		onBeforeSubmit?.();
-		await chatLayoutState.handleEdit(messageId, opts);
+		const intent = submitIntent;
+		// reset intent so future Enter-key submits default to 'edit'
+		submitIntent = 'edit';
+		if (intent !== 'branch') onBeforeSubmit?.();
+		if (intent === 'branch') {
+			await chatLayoutState.handleBranchEdit(messageId, opts);
+		} else {
+			await chatLayoutState.handleEdit(messageId, opts);
+		}
 		onDone();
 	}
 </script>
@@ -105,7 +119,28 @@
 				</div>
 				<div class="flex items-center gap-2">
 					<Button variant="ghost" onclick={onDone}>Cancel</Button>
-					<PromptInput.Submit />
+					<PromptInput.SplitSubmit>
+						{#snippet children({ submit })}
+							<SplitButton.Item
+								onSelect={() => {
+									submitIntent = 'branch';
+									submit();
+								}}
+							>
+								<SplitIcon />
+								Branch and send
+							</SplitButton.Item>
+							<SplitButton.Item
+								onSelect={() => {
+									submitIntent = 'edit';
+									submit();
+								}}
+							>
+								<SendIcon />
+								Send
+							</SplitButton.Item>
+						{/snippet}
+					</PromptInput.SplitSubmit>
 				</div>
 			</PromptInput.Footer>
 		</PromptInput.Content>

--- a/src/lib/features/chat/chat-message-edit.svelte
+++ b/src/lib/features/chat/chat-message-edit.svelte
@@ -1,0 +1,108 @@
+<!-- svelte-ignore state_referenced_locally -->
+<script lang="ts">
+	import * as PromptInput from '$lib/features/chat/components/prompt-input';
+	import ModelPickerBasic from '$lib/features/models/components/models-picker-basic.svelte';
+	import ModelPickerAdvanced from '$lib/features/models/components/models-picker-advanced.svelte';
+	import ReasoningEffortPicker from './components/reasoning-effort-picker.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { RiAlertLine as AlertIcon } from 'remixicon-svelte';
+	import { useChatLayout } from './chat.svelte.js';
+	import type { Id } from '$lib/convex/_generated/dataModel';
+	import type { ModelId } from './types.js';
+	import type { ReasoningEffort } from '$lib/convex/schema.js';
+	import type { ChatPromptAttachment } from './components/prompt-input/prompt-input.svelte.js';
+	import { ChatAttachmentUploader } from './chat-attachment-uploader.svelte.js';
+	import { supportsImages } from '$lib/features/models/openrouter';
+
+	type Props = {
+		messageId: Id<'messages'>;
+		initialContent: string;
+		initialAttachments: ChatPromptAttachment[];
+		initialModelId: ModelId | null;
+		initialReasoningEffort: ReasoningEffort;
+		onDone: () => void;
+	};
+
+	let {
+		messageId,
+		initialContent,
+		initialAttachments,
+		initialModelId,
+		initialReasoningEffort,
+		onDone
+	}: Props = $props();
+
+	const chatLayoutState = useChatLayout();
+
+	let value = $state(initialContent);
+	let modelId = $state<ModelId | null>(initialModelId);
+	let reasoningEffort = $state<ReasoningEffort>(initialReasoningEffort);
+	let attachments = $state<ChatPromptAttachment[]>([...initialAttachments]);
+
+	const uploader = new ChatAttachmentUploader();
+
+	const submitOnEnter = $derived(chatLayoutState.userSettingsQuery.data?.submitOnEnter ?? false);
+
+	const modelSupportsReasoning = $derived(chatLayoutState.modelSupportsReasoning(modelId));
+
+	const selectedModel = $derived(chatLayoutState.models.find((m) => m.id === modelId));
+	const showImageUnsupportedBanner = $derived.by(() => {
+		const model = selectedModel;
+		return attachments.length > 0 && model ? !supportsImages(model) : false;
+	});
+
+	async function handleSubmit(opts: {
+		input: string;
+		modelId: ModelId;
+		attachments: ChatPromptAttachment[];
+		reasoningEffort: ReasoningEffort;
+	}) {
+		await chatLayoutState.handleEdit(messageId, opts);
+		onDone();
+	}
+</script>
+
+<PromptInput.Root
+	bind:value
+	bind:modelId
+	bind:reasoningEffort
+	bind:attachments
+	{submitOnEnter}
+	optimisticClear={false}
+	onSubmit={handleSubmit}
+	onUpload={uploader.uploadMany}
+	onDeleteAttachment={uploader.deleteAttachment}
+	class="group/prompt-input w-full"
+>
+	<PromptInput.Banner dismissedByError={false} dismissed={!showImageUnsupportedBanner}>
+		<PromptInput.BannerContent>
+			<div class="flex items-center gap-2">
+				<AlertIcon class="size-4 text-destructive shrink-0" />
+				<p class="text-sm text-destructive">
+					This model doesn't support images. Remove attachments or switch models to avoid errors.
+				</p>
+			</div>
+		</PromptInput.BannerContent>
+	</PromptInput.Banner>
+	<PromptInput.Content>
+		<PromptInput.AttachmentList />
+		<PromptInput.Textarea placeholder="Edit your message..." />
+		<PromptInput.Footer class="justify-between">
+			<div class="flex items-center gap-2">
+				{#if chatLayoutState.isAdvancedMode}
+					<ModelPickerAdvanced />
+				{:else}
+					<ModelPickerBasic models={chatLayoutState.availableBasicModels} />
+				{/if}
+				<PromptInput.AttachmentButton />
+				{#if chatLayoutState.isAdvancedMode && modelSupportsReasoning}
+					<ReasoningEffortPicker />
+				{/if}
+			</div>
+			<div class="flex items-center gap-2">
+				<Button variant="ghost" size="sm" onclick={onDone}>Cancel</Button>
+				<PromptInput.Submit />
+			</div>
+		</PromptInput.Footer>
+	</PromptInput.Content>
+</PromptInput.Root>

--- a/src/lib/features/chat/chat-message-edit.svelte
+++ b/src/lib/features/chat/chat-message-edit.svelte
@@ -21,6 +21,7 @@
 		initialModelId: ModelId | null;
 		initialReasoningEffort: ReasoningEffort;
 		onDone: () => void;
+		onBeforeSubmit?: () => void;
 	};
 
 	let {
@@ -29,7 +30,8 @@
 		initialAttachments,
 		initialModelId,
 		initialReasoningEffort,
-		onDone
+		onDone,
+		onBeforeSubmit
 	}: Props = $props();
 
 	const chatLayoutState = useChatLayout();
@@ -57,52 +59,55 @@
 		attachments: ChatPromptAttachment[];
 		reasoningEffort: ReasoningEffort;
 	}) {
+		onBeforeSubmit?.();
 		await chatLayoutState.handleEdit(messageId, opts);
 		onDone();
 	}
 </script>
 
-<PromptInput.Root
-	bind:value
-	bind:modelId
-	bind:reasoningEffort
-	bind:attachments
-	{submitOnEnter}
-	optimisticClear={false}
-	onSubmit={handleSubmit}
-	onUpload={uploader.uploadMany}
-	onDeleteAttachment={uploader.deleteAttachment}
-	class="group/prompt-input w-full"
->
-	<PromptInput.Banner dismissedByError={false} dismissed={!showImageUnsupportedBanner}>
-		<PromptInput.BannerContent>
-			<div class="flex items-center gap-2">
-				<AlertIcon class="size-4 text-destructive shrink-0" />
-				<p class="text-sm text-destructive">
-					This model doesn't support images. Remove attachments or switch models to avoid errors.
-				</p>
-			</div>
-		</PromptInput.BannerContent>
-	</PromptInput.Banner>
-	<PromptInput.Content>
-		<PromptInput.AttachmentList />
-		<PromptInput.Textarea placeholder="Edit your message..." />
-		<PromptInput.Footer class="justify-between">
-			<div class="flex items-center gap-2">
-				{#if chatLayoutState.isAdvancedMode}
-					<ModelPickerAdvanced />
-				{:else}
-					<ModelPickerBasic models={chatLayoutState.availableBasicModels} />
-				{/if}
-				<PromptInput.AttachmentButton />
-				{#if chatLayoutState.isAdvancedMode && modelSupportsReasoning}
-					<ReasoningEffortPicker />
-				{/if}
-			</div>
-			<div class="flex items-center gap-2">
-				<Button variant="ghost" size="sm" onclick={onDone}>Cancel</Button>
-				<PromptInput.Submit />
-			</div>
-		</PromptInput.Footer>
-	</PromptInput.Content>
-</PromptInput.Root>
+<div class="has-[[data-slot=prompt-input-banner][data-state=open]]:pt-8 transition-[padding]">
+	<PromptInput.Root
+		bind:value
+		bind:modelId
+		bind:reasoningEffort
+		bind:attachments
+		{submitOnEnter}
+		optimisticClear={false}
+		onSubmit={handleSubmit}
+		onUpload={uploader.uploadMany}
+		onDeleteAttachment={uploader.deleteAttachment}
+		class="group/prompt-input w-full"
+	>
+		<PromptInput.Banner dismissedByError={false} dismissed={!showImageUnsupportedBanner}>
+			<PromptInput.BannerContent>
+				<div class="flex items-center gap-2">
+					<AlertIcon class="size-4 text-destructive shrink-0" />
+					<p class="text-sm text-destructive">
+						This model doesn't support images. Remove attachments or switch models to avoid errors.
+					</p>
+				</div>
+			</PromptInput.BannerContent>
+		</PromptInput.Banner>
+		<PromptInput.Content>
+			<PromptInput.AttachmentList />
+			<PromptInput.Textarea placeholder="Edit your message..." />
+			<PromptInput.Footer class="justify-between">
+				<div class="flex items-center gap-2">
+					{#if chatLayoutState.isAdvancedMode}
+						<ModelPickerAdvanced />
+					{:else}
+						<ModelPickerBasic models={chatLayoutState.availableBasicModels} />
+					{/if}
+					<PromptInput.AttachmentButton />
+					{#if chatLayoutState.isAdvancedMode && modelSupportsReasoning}
+						<ReasoningEffortPicker />
+					{/if}
+				</div>
+				<div class="flex items-center gap-2">
+					<Button variant="ghost" size="sm" onclick={onDone}>Cancel</Button>
+					<PromptInput.Submit />
+				</div>
+			</PromptInput.Footer>
+		</PromptInput.Content>
+	</PromptInput.Root>
+</div>

--- a/src/lib/features/chat/chat-message.svelte
+++ b/src/lib/features/chat/chat-message.svelte
@@ -13,6 +13,11 @@
 	import { useMedia } from '$lib/hooks/use-media.svelte';
 	import ChatAttachmentDisplay from './chat-attachment-display.svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { Button } from '$lib/components/ui/button';
+	import { RiPencilLine as PencilIcon } from 'remixicon-svelte';
+	import { useChatLayout, useChatView } from './chat.svelte.js';
+	import ChatMessageEdit from './chat-message-edit.svelte';
+	import { ModelIdCtx, ReasoningEffortCtx } from '$lib/context.svelte.js';
 
 	const chatMessageVariants = tv({
 		base: 'rounded-lg max-w-full w-fit group/message',
@@ -32,6 +37,21 @@
 	};
 
 	let { message, createdMessages = $bindable(null), apiKey, systemPrompt }: Props = $props();
+
+	const chatLayoutState = useChatLayout();
+	const chatViewState = useChatView();
+
+	const modelIdCtx = ModelIdCtx.get();
+	const reasoningEffortCtx = ReasoningEffortCtx.get();
+
+	let editing = $state(false);
+
+	const canEdit = $derived(
+		message.role === 'user' &&
+			chatLayoutState.user !== null &&
+			message.userId === chatLayoutState.user.id &&
+			!chatViewState.chat?.generating
+	);
 
 	// this is weird but basically we only care if we transition to a driven state not if we transition out of it
 	let driven = $state(false);
@@ -67,11 +87,11 @@
 
 <div
 	class={cn('flex flex-col gap-1 max-w-full w-full group/message-container', {
-		'self-end': message.role === 'user',
-		'self-start': message.role === 'assistant'
+		'self-end': message.role === 'user' && !editing,
+		'self-start': message.role === 'assistant' || editing
 	})}
 >
-	{#if message.role === 'user'}
+	{#if message.role === 'user' && !editing}
 		{#if message.attachments}
 			<div class="w-full justify-end flex items-center gap-2">
 				{#each message.attachments as attachment (attachment.key)}
@@ -80,22 +100,39 @@
 			</div>
 		{/if}
 	{/if}
-	<div data-message-role={message.role} class={chatMessageVariants({ role: message.role })}>
-		{#if message.role === 'assistant'}
-			{#if message.content !== undefined}
-				<ChatAssistantMessage {message} animationEnabled={false} />
-			{:else if message.error}
-				<span class="text-destructive">{message.error}</span>
+	{#if editing && message.role === 'user'}
+		<ChatMessageEdit
+			messageId={message._id}
+			initialContent={message.content}
+			initialAttachments={message.attachments.map((a) => ({
+				url: a.url,
+				key: a.key,
+				mediaType: a.mediaType,
+				fileName: a.fileName
+			}))}
+			initialModelId={(message.chatSettings.modelId as typeof modelIdCtx.current) ??
+				modelIdCtx.current}
+			initialReasoningEffort={message.chatSettings.reasoningEffort ?? reasoningEffortCtx.current}
+			onDone={() => (editing = false)}
+		/>
+	{:else}
+		<div data-message-role={message.role} class={chatMessageVariants({ role: message.role })}>
+			{#if message.role === 'assistant'}
+				{#if message.content !== undefined}
+					<ChatAssistantMessage {message} animationEnabled={false} />
+				{:else if message.error}
+					<span class="text-destructive">{message.error}</span>
+				{:else}
+					{#key createdMessages?.has(message._id)}
+						<ChatStreamedContent {message} {driven} {apiKey} {systemPrompt} />
+					{/key}
+				{/if}
 			{:else}
-				{#key createdMessages?.has(message._id)}
-					<ChatStreamedContent {message} {driven} {apiKey} {systemPrompt} />
-				{/key}
+				<Streamdown content={message.content} animationEnabled={false} />
 			{/if}
-		{:else}
-			<Streamdown content={message.content} animationEnabled={false} />
-		{/if}
-	</div>
-	{#if message.content !== undefined}
+		</div>
+	{/if}
+	{#if message.content !== undefined && !editing}
 		<div
 			class="justify-between w-full group-hover/message-container:opacity-100 md:opacity-0 flex items-center gap-1 transition-opacity duration-200"
 		>
@@ -128,6 +165,23 @@
 				{/if}
 			</div>
 			<div class="flex items-center gap-1">
+				{#if canEdit}
+					<Tooltip.Provider>
+						<Tooltip.Root>
+							<Tooltip.Trigger>
+								<Button
+									variant="ghost"
+									size="icon"
+									onclick={() => (editing = true)}
+									aria-label="Edit message"
+								>
+									<PencilIcon />
+								</Button>
+							</Tooltip.Trigger>
+							<Tooltip.Content>Edit message</Tooltip.Content>
+						</Tooltip.Root>
+					</Tooltip.Provider>
+				{/if}
 				<ChatBranchButton {message} bind:createdMessages />
 				{#if message.content}
 					<Tooltip.Provider>

--- a/src/lib/features/chat/chat-message.svelte
+++ b/src/lib/features/chat/chat-message.svelte
@@ -34,9 +34,16 @@
 		createdMessages: Set<Id<'messages'>> | null;
 		apiKey: string | null;
 		systemPrompt: string | null;
+		onBeforeEditSubmit?: () => void;
 	};
 
-	let { message, createdMessages = $bindable(null), apiKey, systemPrompt }: Props = $props();
+	let {
+		message,
+		createdMessages = $bindable(null),
+		apiKey,
+		systemPrompt,
+		onBeforeEditSubmit
+	}: Props = $props();
 
 	const chatLayoutState = useChatLayout();
 	const chatViewState = useChatView();
@@ -113,6 +120,7 @@
 			initialModelId={(message.chatSettings.modelId as typeof modelIdCtx.current) ??
 				modelIdCtx.current}
 			initialReasoningEffort={message.chatSettings.reasoningEffort ?? reasoningEffortCtx.current}
+			onBeforeSubmit={onBeforeEditSubmit}
 			onDone={() => (editing = false)}
 		/>
 	{:else}

--- a/src/lib/features/chat/chat-view.svelte
+++ b/src/lib/features/chat/chat-view.svelte
@@ -193,6 +193,7 @@
 							{message}
 							apiKey={chatLayoutState.apiKey}
 							systemPrompt={chatLayoutState.userSettingsQuery.data?.systemPrompt ?? null}
+							onBeforeEditSubmit={() => autoScroll.scrollToBottom(false, 'instant')}
 							bind:createdMessages={chatLayoutState.createdMessages}
 						/>
 					{/each}

--- a/src/lib/features/chat/chat.svelte.ts
+++ b/src/lib/features/chat/chat.svelte.ts
@@ -64,6 +64,7 @@ class ChatLayoutState {
 		this.handleSubmit = this.handleSubmit.bind(this);
 		this.handleStop = this.handleStop.bind(this);
 		this.handleEdit = this.handleEdit.bind(this);
+		this.handleBranchEdit = this.handleBranchEdit.bind(this);
 	}
 
 	get isAdvancedMode() {
@@ -145,6 +146,60 @@ class ChatLayoutState {
 		await this.client.mutation(api.chats.stopGenerating, {
 			chatId: this.chatId
 		});
+	}
+
+	async handleBranchEdit(
+		messageId: Id<'messages'>,
+		{
+			input,
+			modelId,
+			attachments,
+			reasoningEffort
+		}: {
+			input: string;
+			modelId: ModelId;
+			attachments: ChatPromptAttachment[];
+			reasoningEffort: ReasoningEffort;
+		}
+	) {
+		if (!this.user) throw new Error('You must be signed in to branch a message!');
+
+		const model = this.models.find((m) => m.id === modelId);
+		if (!model) throw new Error(`Model with id: ${modelId} not found`);
+
+		try {
+			const { newChatId, newAssistantMessageId } = await this.client.mutation(
+				api.chats.branchFromMessage,
+				{
+					message: {
+						_id: messageId,
+						role: 'user',
+						modelId,
+						supportedParameters: model.supported_parameters,
+						inputModalities: model.architecture.input_modalities,
+						outputModalities: model.architecture.output_modalities,
+						reasoningEffort:
+							this.isAdvancedMode && this.modelSupportsReasoning(modelId)
+								? reasoningEffort
+								: 'default',
+						content: input,
+						attachments
+					},
+					apiKey: this.apiKey ?? ''
+				}
+			);
+
+			if (newAssistantMessageId) {
+				this.createdMessages.add(newAssistantMessageId);
+			}
+
+			await goto(resolve(`/chat/${newChatId}`));
+		} catch (error) {
+			if (error instanceof ConvexError) {
+				throw new Error(error.data, { cause: error });
+			}
+			throw error;
+		}
 	}
 
 	async handleEdit(

--- a/src/lib/features/chat/chat.svelte.ts
+++ b/src/lib/features/chat/chat.svelte.ts
@@ -2,7 +2,11 @@ import { useQueryWithFallback, type Query } from '$lib/convex.svelte';
 import { api } from '$lib/convex/_generated/api';
 import type { Doc, Id } from '$lib/convex/_generated/dataModel';
 import type { User } from '@workos-inc/node';
-import type { OnSubmit } from './components/prompt-input/prompt-input.svelte.js';
+import type {
+	ChatPromptAttachment,
+	OnSubmit
+} from './components/prompt-input/prompt-input.svelte.js';
+import type { ReasoningEffort } from '$lib/convex/schema.js';
 import { useConvexClient } from 'convex-svelte';
 import { page } from '$app/state';
 import { goto } from '$app/navigation';
@@ -59,6 +63,7 @@ class ChatLayoutState {
 
 		this.handleSubmit = this.handleSubmit.bind(this);
 		this.handleStop = this.handleStop.bind(this);
+		this.handleEdit = this.handleEdit.bind(this);
 	}
 
 	get isAdvancedMode() {
@@ -140,6 +145,53 @@ class ChatLayoutState {
 		await this.client.mutation(api.chats.stopGenerating, {
 			chatId: this.chatId
 		});
+	}
+
+	async handleEdit(
+		messageId: Id<'messages'>,
+		{
+			input,
+			modelId,
+			attachments,
+			reasoningEffort
+		}: {
+			input: string;
+			modelId: ModelId;
+			attachments: ChatPromptAttachment[];
+			reasoningEffort: ReasoningEffort;
+		}
+	) {
+		if (!this.user) throw new Error('You must be signed in to edit messages!');
+
+		const model = this.models.find((m) => m.id === modelId);
+		if (!model) throw new Error(`Model with id: ${modelId} not found`);
+
+		try {
+			const { assistantMessageId } = await this.client.mutation(api.messages.editMessage, {
+				messageId,
+				apiKey: this.apiKey ?? '',
+				prompt: {
+					input,
+					modelId,
+					attachments,
+					supportedParameters: model.supported_parameters,
+					inputModalities: model.architecture.input_modalities,
+					outputModalities: model.architecture.output_modalities,
+					reasoningEffort:
+						this.isAdvancedMode && this.modelSupportsReasoning(modelId)
+							? reasoningEffort
+							: 'default'
+				}
+			});
+
+			this.createdMessages.add(assistantMessageId);
+		} catch (error) {
+			if (error instanceof ConvexError) {
+				throw new Error(error.data, { cause: error });
+			}
+
+			throw error;
+		}
 	}
 
 	handleSubmit: OnSubmit = async ({ input, modelId, attachments, reasoningEffort }) => {

--- a/src/lib/features/chat/components/prompt-input/index.ts
+++ b/src/lib/features/chat/components/prompt-input/index.ts
@@ -4,6 +4,7 @@ import AttachmentList from './prompt-input-attachment-list.svelte';
 import Textarea from './prompt-input-textarea.svelte';
 import Footer from './prompt-input-footer.svelte';
 import Submit from './prompt-input-submit.svelte';
+import SplitSubmit from './prompt-input-split-submit.svelte';
 import Banner from './prompt-input-banner.svelte';
 import BannerContent from './prompt-input-banner-content.svelte';
 import BannerDismiss from './prompt-input-banner-dismiss.svelte';
@@ -17,6 +18,7 @@ export {
 	Textarea,
 	Footer,
 	Submit,
+	SplitSubmit,
 	Banner,
 	Content,
 	BannerContent,
@@ -30,6 +32,7 @@ export {
 	Textarea as PromptInputTextarea,
 	Footer as PromptInputFooter,
 	Submit as PromptInputSubmit,
+	SplitSubmit as PromptInputSplitSubmit,
 	Banner as PromptInputBanner,
 	Content as PromptInputContent,
 	BannerContent as PromptInputBannerContent,

--- a/src/lib/features/chat/components/prompt-input/prompt-input-split-submit.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-split-submit.svelte
@@ -12,7 +12,8 @@
 	import type { Snippet } from 'svelte';
 
 	type Props = Omit<ButtonElementProps, 'loading' | 'children'> & {
-		children?: Snippet<[{ submit: () => Promise<void> }]>;
+		children?: Snippet;
+		primaryIcon?: Snippet;
 		menuAriaLabel?: string;
 	};
 
@@ -22,6 +23,7 @@
 		disabled,
 		onclick,
 		children,
+		primaryIcon,
 		menuAriaLabel = 'More send options',
 		...rest
 	}: Props = $props();
@@ -30,10 +32,6 @@
 		disabled: box.with(() => disabled),
 		onclick: box.with(() => onclick)
 	});
-
-	async function submit() {
-		await submitState.rootState.submit(submitState.rootState.opts.value.current);
-	}
 </script>
 
 <SplitButton.Root>
@@ -47,7 +45,11 @@
 		{#if submitState.generating}
 			<StopIcon />
 		{:else if !submitState.rootState.loading}
-			<SendIcon class="group-data-[loading=true]:hidden" />
+			{#if primaryIcon}
+				{@render primaryIcon()}
+			{:else}
+				<SendIcon class="group-data-[loading=true]:hidden" />
+			{/if}
 		{/if}
 	</Button>
 	<SplitButton.Trigger
@@ -59,6 +61,6 @@
 		<ChevronDownIcon />
 	</SplitButton.Trigger>
 	<SplitButton.Content align="end" side="top">
-		{@render children?.({ submit })}
+		{@render children?.()}
 	</SplitButton.Content>
 </SplitButton.Root>

--- a/src/lib/features/chat/components/prompt-input/prompt-input-split-submit.svelte
+++ b/src/lib/features/chat/components/prompt-input/prompt-input-split-submit.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import { Button, type ButtonElementProps } from '$lib/components/ui/button';
+	import * as SplitButton from '$lib/components/ui/split-button';
+	import { cn } from '$lib/utils';
+	import {
+		RiSendPlaneLine as SendIcon,
+		RiStopLargeLine as StopIcon,
+		RiArrowDownSLine as ChevronDownIcon
+	} from 'remixicon-svelte';
+	import { usePromptInputSubmit } from './prompt-input.svelte.js';
+	import { box } from 'svelte-toolbelt';
+	import type { Snippet } from 'svelte';
+
+	type Props = Omit<ButtonElementProps, 'loading' | 'children'> & {
+		children?: Snippet<[{ submit: () => Promise<void> }]>;
+		menuAriaLabel?: string;
+	};
+
+	let {
+		variant = 'default',
+		class: className,
+		disabled,
+		onclick,
+		children,
+		menuAriaLabel = 'More send options',
+		...rest
+	}: Props = $props();
+
+	const submitState = usePromptInputSubmit({
+		disabled: box.with(() => disabled),
+		onclick: box.with(() => onclick)
+	});
+
+	async function submit() {
+		await submitState.rootState.submit(submitState.rootState.opts.value.current);
+	}
+</script>
+
+<SplitButton.Root>
+	<Button
+		{variant}
+		size="icon"
+		class={cn('group relative rounded-r-none data-[generating=true]:animate-pulse', className)}
+		{...submitState.props}
+		{...rest}
+	>
+		{#if submitState.generating}
+			<StopIcon />
+		{:else if !submitState.rootState.loading}
+			<SendIcon class="group-data-[loading=true]:hidden" />
+		{/if}
+	</Button>
+	<SplitButton.Trigger
+		{variant}
+		size="icon"
+		disabled={submitState.rootState.loading || submitState.generating}
+		aria-label={menuAriaLabel}
+	>
+		<ChevronDownIcon />
+	</SplitButton.Trigger>
+	<SplitButton.Content align="end" side="top">
+		{@render children?.({ submit })}
+	</SplitButton.Content>
+</SplitButton.Root>


### PR DESCRIPTION
## Summary
This PR adds the ability for users to edit their own messages in a chat conversation. When a message is edited, all subsequent messages in the conversation are deleted, and a new assistant response is generated based on the edited message.

## Key Changes

- **Backend mutation (`editMessage`)**: New mutation in `src/lib/convex/messages.ts` that:
  - Validates user ownership and authorization
  - Prevents editing when a response is being generated
  - Enforces rate limiting for free users
  - Deletes all messages created after the edited message
  - Updates the edited message with new content and attachments
  - Generates a new assistant response stream

- **Edit UI component (`ChatMessageEdit.svelte`)**: New component that provides an editing interface with:
  - Message content textarea
  - Model selection (basic and advanced modes)
  - Attachment management
  - Reasoning effort picker (for advanced mode)
  - Cancel and submit buttons

- **Message display updates (`ChatMessageMessage.svelte`)**: 
  - Added edit button visible on hover for user's own messages (when not generating)
  - Integrated edit mode that replaces the message display with the edit component
  - Conditional rendering to show edit UI or normal message display

- **Chat state management (`chat.svelte.ts`)**:
  - New `handleEdit` method that calls the backend mutation
  - Handles model validation and parameter preparation
  - Manages created messages tracking for the new assistant response

## Implementation Details

- Edit functionality is only available for user messages that the current user created
- Editing is disabled while a response is being generated
- All messages after the edited message are automatically removed to maintain conversation coherence
- The edited message preserves its position in the conversation
- Attachments can be modified during editing
- Model selection and reasoning effort settings are preserved from the edited message

https://claude.ai/code/session_013TPstEFBnyMbn9thzjBG4q