### PR TITLE
Hide message edit button on mobile

### DIFF
--- a/src/lib/features/chat/chat-message.svelte
+++ b/src/lib/features/chat/chat-message.svelte
@@ -53,11 +53,14 @@
 
 	let editing = $state(false);
 
+	const media = useMedia();
+
 	const canEdit = $derived(
 		message.role === 'user' &&
 			chatLayoutState.user !== null &&
 			message.userId === chatLayoutState.user.id &&
-			!chatViewState.chat?.generating
+			!chatViewState.chat?.generating &&
+			media.md
 	);
 
 	// this is weird but basically we only care if we transition to a driven state not if we transition out of it
@@ -88,8 +91,6 @@
 		}
 		return null;
 	});
-
-	const media = useMedia();
 </script>
 
 <div


### PR DESCRIPTION
## Summary
- The message edit UI doesn't fit well on small screens, so gate the edit button behind the `md` breakpoint (768px).

## Test plan
- [ ] Resize browser below 768px — edit pencil button should not appear on user messages
- [ ] Resize browser at/above 768px — edit pencil button appears and functions as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)