### PR TITLE
Mark chat as read when a response arrives while viewing it

### DIFF
--- a/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/[chatId]/(chat)/+layout.svelte
+++ b/src/routes/(app)/(chat-data)/(chat-sidebar)/chat/[chatId]/(chat)/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { afterNavigate } from '$app/navigation';
 	import { useConvexClient } from 'convex-svelte';
 	import type { Id } from '$lib/convex/_generated/dataModel';
 	import { api } from '$lib/convex/_generated/api';
@@ -13,10 +12,12 @@
 
 	const convex = useConvexClient();
 
-	// set unread to false once we navigate to the chat
-	afterNavigate(() => {
+	// Mark the chat as read while the user is viewing it. This reacts to the
+	// chat's `unread` flag, so it covers both navigating into the chat and a
+	// new response landing while we're already on it.
+	$effect(() => {
 		const id = page.params.chatId as Id<'chats'> | undefined;
-		if (!id || chatViewState.chat?.unread === false) return;
+		if (!id || chatViewState.chat?.unread !== true) return;
 		convex.mutation(api.chats.markRead, { chatId: id });
 	});
 </script>


### PR DESCRIPTION
## Problem

When you're currently viewing a chat and a response lands, the chat stays marked as unread. You have to navigate away and back for it to be marked read.

## Cause

The chat layout only called `chats.markRead` inside `afterNavigate`, so it only fired on navigation. When a new assistant message set `unread: true` while you were already on the chat, nothing flipped it back.

## Fix

Replaced the `afterNavigate` handler with a reactive `$effect` that watches the chat's `unread` flag. Whenever the currently-viewed chat is unread, it marks it read — covering both navigating into a chat and a new response arriving while you're already on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWe9DqJmRvVkG8BwhppgAE)_